### PR TITLE
feat: enhance payment links with get method and missing fields

### DIFF
--- a/src/Clients/PaymentLinksClient.php
+++ b/src/Clients/PaymentLinksClient.php
@@ -12,4 +12,9 @@ class PaymentLinksClient extends AbstractClient
     {
         return $this->post('payment-links', $data->toArray());
     }
+
+    public function getPaymentLink(string $uuid): array
+    {
+        return $this->get('payment-links/' . $uuid);
+    }
 }

--- a/src/Structs/CreatePaymentLinkData.php
+++ b/src/Structs/CreatePaymentLinkData.php
@@ -18,6 +18,11 @@ class CreatePaymentLinkData extends AbstractStruct
     protected string $description;
     protected bool $askAdditionalInfo;
     protected string $expiresAt;
+    protected string $type;
+    protected string $returnUrl;
+    protected string $merchantReference;
+    protected bool $showShippingOptions;
+    protected string $customerCountry;
 
     /**
      * Description of the payment link that is shown on the payment page
@@ -71,6 +76,96 @@ class CreatePaymentLinkData extends AbstractStruct
     public function setExpiresAt(string $expiresAt): self
     {
         $this->expiresAt = $expiresAt;
+
+        return $this;
+    }
+
+    /**
+     * Payment link type. Available values: 'one_time', 'reusable'. Defaults to 'reusable'.
+     */
+    public function getType(): ?string
+    {
+        return $this->type ?? null;
+    }
+
+    /**
+     * Payment link type. Available values: 'one_time', 'reusable'. Defaults to 'reusable'.
+     */
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * The URL where the customer will be redirected after payment.
+     */
+    public function getReturnUrl(): ?string
+    {
+        return $this->returnUrl ?? null;
+    }
+
+    /**
+     * The URL where the customer will be redirected after payment.
+     */
+    public function setReturnUrl(string $returnUrl): self
+    {
+        $this->returnUrl = $returnUrl;
+
+        return $this;
+    }
+
+    /**
+     * Your unique order reference. Only for 'one_time' links.
+     */
+    public function getMerchantReference(): ?string
+    {
+        return $this->merchantReference ?? null;
+    }
+
+    /**
+     * Your unique order reference. Only for 'one_time' links.
+     */
+    public function setMerchantReference(string $merchantReference): self
+    {
+        $this->merchantReference = $merchantReference;
+
+        return $this;
+    }
+
+    /**
+     * If true, shows shipping options section. Requires askAdditionalInfo=true and customerCountry.
+     */
+    public function getShowShippingOptions(): ?bool
+    {
+        return $this->showShippingOptions ?? null;
+    }
+
+    /**
+     * If true, shows shipping options section. Requires askAdditionalInfo=true and customerCountry.
+     */
+    public function setShowShippingOptions(bool $showShippingOptions): self
+    {
+        $this->showShippingOptions = $showShippingOptions;
+
+        return $this;
+    }
+
+    /**
+     * ISO 3166-1 alpha-2 country code. Required when showShippingOptions is true.
+     */
+    public function getCustomerCountry(): ?string
+    {
+        return $this->customerCountry ?? null;
+    }
+
+    /**
+     * ISO 3166-1 alpha-2 country code. Required when showShippingOptions is true.
+     */
+    public function setCustomerCountry(string $customerCountry): self
+    {
+        $this->customerCountry = $customerCountry;
 
         return $this;
     }

--- a/tests/Integration/Clients/PaymentLinksClientTest.php
+++ b/tests/Integration/Clients/PaymentLinksClientTest.php
@@ -25,4 +25,21 @@ class PaymentLinksClientTest extends IntegrationTestCase
         $this->assertArrayHasKey('url', $return);
         $this->assertArrayHasKey('shortUrl', $return);
     }
+
+    public function testGetPaymentLink(): void
+    {
+        $data = (new CreatePaymentLinkData())
+            ->setDescription('Get test')
+            ->setCurrency('EUR')
+            ->setAmount(5.00)
+            ->setLocale('en')
+            ->setAskAdditionalInfo(false)
+            ->setExpiresAt(date('c', strtotime('+1 hour')));
+
+        $created = $this->getMontonioClient()->paymentLinks()->createPaymentLink($data);
+
+        $fetched = $this->getMontonioClient()->paymentLinks()->getPaymentLink($created['uuid']);
+
+        $this->assertSame($created['uuid'], $fetched['uuid']);
+    }
 }

--- a/tests/Unit/Structs/CreatePaymentLinkDataTest.php
+++ b/tests/Unit/Structs/CreatePaymentLinkDataTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs;
+
+use Montonio\Structs\CreatePaymentLinkData;
+use Tests\BaseTestCase;
+
+class CreatePaymentLinkDataTest extends BaseTestCase
+{
+    public function testAllFields(): void
+    {
+        $data = (new CreatePaymentLinkData())
+            ->setDescription('Test payment')
+            ->setCurrency('EUR')
+            ->setAmount(10.00)
+            ->setLocale('en')
+            ->setAskAdditionalInfo(true)
+            ->setExpiresAt('2026-12-31T23:59:59Z')
+            ->setType('one_time')
+            ->setReturnUrl('https://example.com/return')
+            ->setMerchantReference('ORDER-123')
+            ->setShowShippingOptions(true)
+            ->setCustomerCountry('EE');
+
+        $array = $data->toArray();
+
+        $this->assertSame('Test payment', $array['description']);
+        $this->assertSame('EUR', $array['currency']);
+        $this->assertSame(10.00, $array['amount']);
+        $this->assertSame('en', $array['locale']);
+        $this->assertTrue($array['askAdditionalInfo']);
+        $this->assertSame('2026-12-31T23:59:59Z', $array['expiresAt']);
+        $this->assertSame('one_time', $array['type']);
+        $this->assertSame('https://example.com/return', $array['returnUrl']);
+        $this->assertSame('ORDER-123', $array['merchantReference']);
+        $this->assertTrue($array['showShippingOptions']);
+        $this->assertSame('EE', $array['customerCountry']);
+    }
+
+    public function testConstructFromArray(): void
+    {
+        $data = new CreatePaymentLinkData([
+            'description' => 'From array',
+            'currency' => 'PLN',
+            'amount' => 50.00,
+            'locale' => 'pl',
+            'askAdditionalInfo' => false,
+            'expiresAt' => '2026-06-01T00:00:00Z',
+            'type' => 'reusable',
+        ]);
+
+        $this->assertSame('From array', $data->getDescription());
+        $this->assertSame('PLN', $data->getCurrency());
+        $this->assertSame('reusable', $data->getType());
+    }
+
+    public function testNullableNewFields(): void
+    {
+        $data = new CreatePaymentLinkData();
+
+        $this->assertNull($data->getType());
+        $this->assertNull($data->getReturnUrl());
+        $this->assertNull($data->getMerchantReference());
+        $this->assertNull($data->getShowShippingOptions());
+        $this->assertNull($data->getCustomerCountry());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,5 +7,5 @@ require_once __DIR__ . '/../vendor/autoload.php';
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
 $dotenv->safeLoad();
 
-define('ACCESS_KEY', getenv('ACCESS_KEY') ?: '');
-define('SECRET_KEY', getenv('SECRET_KEY') ?: str_repeat('x', 32));
+define('ACCESS_KEY', $_ENV['ACCESS_KEY'] ?? getenv('ACCESS_KEY') ?: '');
+define('SECRET_KEY', $_ENV['SECRET_KEY'] ?? getenv('SECRET_KEY') ?: str_repeat('x', 32));


### PR DESCRIPTION
- Add `getPaymentLink()` to `PaymentLinksClient`
- Add missing fields to `CreatePaymentLinkData`: type, returnUrl, merchantReference, showShippingOptions, customerCountry
- Fix bootstrap.php to read from `$_ENV` (dotenv compatibility)