### PR TITLE
docs: add webhook verification documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,24 @@ header("Location: $paymentUrl");
 
 You can find the documentation with the response data example, in the [official docs](https://docs.montonio.com/api/stargate/guides/orders#4-submitting-the-token).
 
+### Webhook verification
+
+When a payment is completed (or updated), Montonio sends a webhook POST request to your `notificationUrl` with a JWT token.
+Use `decodeToken()` to verify the signature and decode the payload:
+
+```php
+// Order webhook: {"orderToken": "<jwt>"}
+$decoded = $client->decodeToken($request['orderToken']);
+echo $decoded->paymentStatus; // 'PAID', 'PENDING', etc.
+echo $decoded->merchantReference; // Your order reference
+
+// Refund webhook: {"refundToken": "<jwt>"}
+$decoded = $client->decodeToken($request['refundToken']);
+echo $decoded->refundStatus; // 'SUCCESSFUL', 'PENDING', etc.
+```
+
+See the [webhooks guide](https://docs.montonio.com/api/stargate/guides/webhooks) for full payload details.
+
 ## License
 
 This library is made available under the MIT License (MIT). Please see [License File](LICENSE) for more information.

--- a/src/Clients/AbstractClient.php
+++ b/src/Clients/AbstractClient.php
@@ -59,6 +59,16 @@ abstract class AbstractClient
         return JWT::encode($payload, $this->getSecretKey(), static::ENCODING_ALGORITHM);
     }
 
+    /**
+     * Decode and verify a JWT token signed with your secret key.
+     *
+     * Use this to verify webhook tokens from Montonio:
+     * - Order webhooks send {"orderToken": "<jwt>"} with fields: uuid, merchantReference, paymentStatus, etc.
+     * - Refund webhooks send {"refundToken": "<jwt>"} with fields: refundUuid, refundStatus, refundAmount, etc.
+     *
+     * @throws \Firebase\JWT\SignatureInvalidException if the token signature is invalid
+     * @throws \Firebase\JWT\ExpiredException if the token has expired
+     */
     public function decodeToken(string $token): stdClass
     {
         return JWT::decode($token, new Key($this->getSecretKey(), static::ENCODING_ALGORITHM));


### PR DESCRIPTION
- Add docblock to `decodeToken()` explaining webhook usage for order and refund tokens
- Add webhook verification section to README with usage examples