### PR TITLE
feat: add embedded payments support (sessions client, BLIK code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,35 @@ echo $decoded->refundStatus; // 'SUCCESSFUL', 'PENDING', etc.
 
 See the [webhooks guide](https://docs.montonio.com/api/stargate/guides/webhooks) for full payload details.
 
+### Embedded card payments
+
+Create a session for the [embedded card payments](https://docs.montonio.com/api/stargate/guides/embedded-cards/) flow, then pass the UUID to the MontonioCheckout JS SDK:
+
+```php
+$session = $client->sessions()->createSession();
+$sessionUuid = $session['uuid']; // Pass to frontend JS SDK
+```
+
+### Embedded BLIK
+
+For [embedded BLIK](https://docs.montonio.com/api/stargate/guides/embedded-blik/) payments, pass the `blikCode` in the payment method options when creating an order:
+
+```php
+$orderData = (new \Montonio\Structs\OrderData())
+    ->setPayment(
+        (new \Montonio\Structs\Payment())
+            ->setMethod(\Montonio\Structs\Payment::METHOD_BLIK)
+            ->setAmount(100.00)
+            ->setCurrency('PLN')
+            ->setMethodOptions(
+                (new \Montonio\Structs\PaymentMethodOptions())
+                    ->setBlikCode('777123')
+            )
+    )
+    // ... other order fields
+;
+```
+
 ## License
 
 This library is made available under the MIT License (MIT). Please see [License File](LICENSE) for more information.

--- a/src/Clients/SessionsClient.php
+++ b/src/Clients/SessionsClient.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Clients;
+
+class SessionsClient extends AbstractClient
+{
+    /**
+     * Create a session for embedded card payments.
+     * Returns an array with 'uuid' — pass this to the MontonioCheckout JS SDK.
+     */
+    public function createSession(): array
+    {
+        return $this->post('sessions');
+    }
+}

--- a/src/MontonioClient.php
+++ b/src/MontonioClient.php
@@ -9,6 +9,7 @@ use Montonio\Clients\OrdersClient;
 use Montonio\Clients\PaymentIntentsClient;
 use Montonio\Clients\PaymentLinksClient;
 use Montonio\Clients\RefundsClient;
+use Montonio\Clients\SessionsClient;
 use Montonio\Clients\StoresClient;
 
 class MontonioClient extends AbstractClient
@@ -46,6 +47,15 @@ class MontonioClient extends AbstractClient
     public function refunds(): RefundsClient
     {
         return new RefundsClient(
+            $this->getAccessKey(),
+            $this->getSecretKey(),
+            $this->getEnvironment(),
+        );
+    }
+
+    public function sessions(): SessionsClient
+    {
+        return new SessionsClient(
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),

--- a/src/Structs/PaymentMethodOptions.php
+++ b/src/Structs/PaymentMethodOptions.php
@@ -15,6 +15,7 @@ class PaymentMethodOptions extends AbstractStruct
     protected string $preferredMethod;
     protected string $preferredLocale;
     protected int $period;
+    protected string $blikCode;
 
     /**
      * Used for `paymentInitiation`.
@@ -100,6 +101,26 @@ class PaymentMethodOptions extends AbstractStruct
     public function setPeriod(int $period): self
     {
         $this->period = $period;
+
+        return $this;
+    }
+
+    /**
+     * Used for embedded `blik` payments.
+     * The 6-digit BLIK code entered by the customer.
+     */
+    public function getBlikCode(): ?string
+    {
+        return $this->blikCode ?? null;
+    }
+
+    /**
+     * Used for embedded `blik` payments.
+     * The 6-digit BLIK code entered by the customer.
+     */
+    public function setBlikCode(string $blikCode): self
+    {
+        $this->blikCode = $blikCode;
 
         return $this;
     }

--- a/tests/Integration/Clients/SessionsClientTest.php
+++ b/tests/Integration/Clients/SessionsClientTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Clients;
+
+use Tests\Integration\IntegrationTestCase;
+
+class SessionsClientTest extends IntegrationTestCase
+{
+    public function testCreateSession(): void
+    {
+        $response = $this->getMontonioClient()->sessions()->createSession();
+
+        $this->assertArrayHasKey('uuid', $response);
+        $this->assertNotEmpty($response['uuid']);
+    }
+}

--- a/tests/Unit/MontonioClientTest.php
+++ b/tests/Unit/MontonioClientTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit;
 
 use Montonio\Clients\OrdersClient;
 use Montonio\Clients\RefundsClient;
+use Montonio\Clients\SessionsClient;
 use Montonio\Clients\StoresClient;
 use Montonio\Structs\OrderData;
 use stdClass;
@@ -54,5 +55,12 @@ class MontonioClientTest extends BaseTestCase
         $client = $this->getMontonioClient()->refunds();
 
         $this->assertInstanceOf(RefundsClient::class, $client);
+    }
+
+    public function testGetSessionsClient(): void
+    {
+        $client = $this->getMontonioClient()->sessions();
+
+        $this->assertInstanceOf(SessionsClient::class, $client);
     }
 }

--- a/tests/Unit/Structs/PaymentMethodOptionsTest.php
+++ b/tests/Unit/Structs/PaymentMethodOptionsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs;
+
+use Montonio\Structs\PaymentMethodOptions;
+use Tests\BaseTestCase;
+
+class PaymentMethodOptionsTest extends BaseTestCase
+{
+    public function testBlikCode(): void
+    {
+        $options = (new PaymentMethodOptions())
+            ->setBlikCode('777123');
+
+        $this->assertSame('777123', $options->getBlikCode());
+
+        $array = $options->toArray();
+        $this->assertSame('777123', $array['blikCode']);
+    }
+
+    public function testBlikCodeNullable(): void
+    {
+        $options = new PaymentMethodOptions();
+
+        $this->assertNull($options->getBlikCode());
+    }
+
+    public function testBlikCodeFromArray(): void
+    {
+        $options = new PaymentMethodOptions([
+            'blikCode' => '555555',
+        ]);
+
+        $this->assertSame('555555', $options->getBlikCode());
+    }
+}


### PR DESCRIPTION
- `SessionsClient` with `createSession()` for `POST /sessions` (embedded card payments)
- Add `blikCode` field to `PaymentMethodOptions` for embedded BLIK payments
- Add embedded cards and BLIK sections to README