### PR TITLE
chore: clean up labels and update release-drafter categories

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,8 +3,8 @@ tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: 'Features'
     labels:
-      - 'feature'
       - 'feat'
+      - 'enhancement'
   - title: 'Bug Fixes'
     labels:
       - 'fix'
@@ -13,7 +13,7 @@ categories:
     labels:
       - 'chore'
       - 'ci'
-      - 'doc'
+      - 'documentation'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   ## Changes


### PR DESCRIPTION
- Remove redundant labels: `feature`, `doc`, `good first issue`
- Update release-drafter to use `enhancement` and `documentation` instead