### PR TITLE
feat: add payouts client with balances, listing, and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,22 @@ $orderData = (new \Montonio\Structs\OrderData())
 ;
 ```
 
+### Payouts
+
+Retrieve [payout reports](https://docs.montonio.com/api/stargate/guides/payouts/) and balances:
+
+```php
+// Get store balances
+$balances = $client->payouts()->getBalances();
+
+// List payouts for a store
+$payouts = $client->payouts()->getPayouts($storeUuid, limit: 50, offset: 0, order: 'DESC');
+
+// Export a payout report (excel or xml)
+$export = $client->payouts()->exportPayout($storeUuid, $payoutUuid, 'excel');
+$downloadUrl = $export['url'];
+```
+
 ## License
 
 This library is made available under the MIT License (MIT). Please see [License File](LICENSE) for more information.

--- a/src/Clients/PayoutsClient.php
+++ b/src/Clients/PayoutsClient.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Clients;
+
+class PayoutsClient extends AbstractClient
+{
+    /**
+     * List payouts for a store.
+     *
+     * @param string $storeUuid  Your store UUID from the Partner System
+     * @param int    $limit      Max number of results (max 150)
+     * @param int    $offset     Pagination offset
+     * @param string $order      Sort direction: 'ASC' or 'DESC'
+     * @param string|null $orderBy Sort field: 'createdAt', 'settlementType', 'totalAmount', 'status'
+     */
+    public function getPayouts(
+        string $storeUuid,
+        int $limit = 50,
+        int $offset = 0,
+        string $order = 'DESC',
+        ?string $orderBy = null
+    ): array {
+        $params = [
+            'limit' => $limit,
+            'offset' => $offset,
+            'order' => $order,
+        ];
+
+        if ($orderBy !== null) {
+            $params['orderBy'] = $orderBy;
+        }
+
+        $query = http_build_query($params);
+
+        return $this->get('stores/' . $storeUuid . '/payouts?' . $query);
+    }
+
+    /**
+     * Export a payout report.
+     *
+     * @param string $storeUuid  Your store UUID
+     * @param string $payoutUuid The payout UUID
+     * @param string $format     Export format: 'excel' or 'xml'
+     * @return array Contains 'url' with a pre-signed download link
+     *
+     * @codeCoverageIgnore Requires actual payouts in the sandbox which can't be created via API
+     */
+    public function exportPayout(string $storeUuid, string $payoutUuid, string $format = 'excel'): array
+    {
+        return $this->get('stores/' . $storeUuid . '/payouts/' . $payoutUuid . '/export-' . $format);
+    }
+
+    /**
+     * Get payout balances for your store.
+     */
+    public function getBalances(): array
+    {
+        return $this->get('store-balances');
+    }
+}

--- a/src/MontonioClient.php
+++ b/src/MontonioClient.php
@@ -8,6 +8,7 @@ use Montonio\Clients\AbstractClient;
 use Montonio\Clients\OrdersClient;
 use Montonio\Clients\PaymentIntentsClient;
 use Montonio\Clients\PaymentLinksClient;
+use Montonio\Clients\PayoutsClient;
 use Montonio\Clients\RefundsClient;
 use Montonio\Clients\SessionsClient;
 use Montonio\Clients\StoresClient;
@@ -38,6 +39,15 @@ class MontonioClient extends AbstractClient
     public function paymentLinks(): PaymentLinksClient
     {
         return new PaymentLinksClient(
+            $this->getAccessKey(),
+            $this->getSecretKey(),
+            $this->getEnvironment(),
+        );
+    }
+
+    public function payouts(): PayoutsClient
+    {
+        return new PayoutsClient(
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),

--- a/tests/Integration/Clients/PayoutsClientTest.php
+++ b/tests/Integration/Clients/PayoutsClientTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Clients;
+
+use Tests\Integration\IntegrationTestCase;
+
+class PayoutsClientTest extends IntegrationTestCase
+{
+    public function testGetBalances(): void
+    {
+        $response = $this->getMontonioClient()->payouts()->getBalances();
+
+        $this->assertArrayHasKey('store', $response);
+        $this->assertArrayHasKey('balances', $response);
+    }
+
+    public function testGetPayouts(): void
+    {
+        $balances = $this->getMontonioClient()->payouts()->getBalances();
+        $storeUuid = $balances['store']['uuid'];
+
+        $response = $this->getMontonioClient()->payouts()->getPayouts($storeUuid, limit: 10);
+
+        $this->assertArrayHasKey('payouts', $response);
+        $this->assertIsArray($response['payouts']);
+    }
+
+    public function testGetPayoutsWithOrderBy(): void
+    {
+        $balances = $this->getMontonioClient()->payouts()->getBalances();
+        $storeUuid = $balances['store']['uuid'];
+
+        $response = $this->getMontonioClient()->payouts()->getPayouts($storeUuid, limit: 10, orderBy: 'createdAt');
+
+        $this->assertArrayHasKey('payouts', $response);
+    }
+
+    public function testExportPayout(): void
+    {
+        $balances = $this->getMontonioClient()->payouts()->getBalances();
+        $storeUuid = $balances['store']['uuid'];
+
+        $payouts = $this->getMontonioClient()->payouts()->getPayouts($storeUuid, limit: 1);
+
+        if (empty($payouts['payouts'])) {
+            $this->markTestSkipped('No payouts available in sandbox to test export.');
+        }
+
+        $payoutUuid = $payouts['payouts'][0]['uuid'];
+        $response = $this->getMontonioClient()->payouts()->exportPayout($storeUuid, $payoutUuid);
+
+        $this->assertArrayHasKey('url', $response);
+    }
+}

--- a/tests/Unit/MontonioClientTest.php
+++ b/tests/Unit/MontonioClientTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use Montonio\Clients\OrdersClient;
+use Montonio\Clients\PayoutsClient;
 use Montonio\Clients\RefundsClient;
 use Montonio\Clients\SessionsClient;
 use Montonio\Clients\StoresClient;
@@ -62,5 +63,12 @@ class MontonioClientTest extends BaseTestCase
         $client = $this->getMontonioClient()->sessions();
 
         $this->assertInstanceOf(SessionsClient::class, $client);
+    }
+
+    public function testGetPayoutsClient(): void
+    {
+        $client = $this->getMontonioClient()->payouts();
+
+        $this->assertInstanceOf(PayoutsClient::class, $client);
     }
 }


### PR DESCRIPTION
- `PayoutsClient` with `getPayouts()`, `exportPayout()`, and `getBalances()`
- Factory method `$montonio->payouts()`
- Add payouts section to README