### PR TITLE
refactor: extract PaymentsAbstractClient from AbstractClient

### DIFF
--- a/src/Clients/AbstractClient.php
+++ b/src/Clients/AbstractClient.php
@@ -11,14 +11,10 @@ use Firebase\JWT\Key;
 use JsonException;
 use Montonio\Exception\CurlErrorException;
 use Montonio\Exception\RequestException;
-use Montonio\MontonioClient;
 use stdClass;
 
 abstract class AbstractClient
 {
-    protected const SANDBOX_URL = 'https://sandbox-stargate.montonio.com/api';
-    protected const LIVE_URL = 'https://stargate.montonio.com/api';
-
     protected const ENCODING_ALGORITHM = 'HS256';
 
     public function __construct(
@@ -26,29 +22,6 @@ abstract class AbstractClient
         private string $secretKey,
         private string $environment,
     ) {}
-
-    protected function get(string $url, array $params = []): array
-    {
-        return $this->call(
-            'GET',
-            $this->getUrl($url),
-            null,
-            [
-                'Content-Type: application/json',
-                'Authorization: Bearer ' . $this->generateToken(),
-            ],
-        );
-    }
-
-    protected function post(string $url, array $payload = []): array
-    {
-        return $this->call(
-            'POST',
-            $this->getUrl($url),
-            json_encode(['data' => $this->generateToken($payload)]),
-            ['Content-Type: application/json'],
-        );
-    }
 
     public function generateToken(array $payload = []): string
     {
@@ -72,13 +45,6 @@ abstract class AbstractClient
     public function decodeToken(string $token): stdClass
     {
         return JWT::decode($token, new Key($this->getSecretKey(), static::ENCODING_ALGORITHM));
-    }
-
-    protected function getUrl(string $path): string
-    {
-        return ($this->isSandbox() ? self::SANDBOX_URL : self::LIVE_URL)
-            . (str_starts_with($path, '/') ? '' : '/')
-            . $path;
     }
 
     private function prepareCurl(string $url): CurlHandle
@@ -127,7 +93,7 @@ abstract class AbstractClient
         $httpStatus = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
         if (200 <= $httpStatus && $httpStatus <= 299) {
             curl_close($ch);
-            return json_decode($response, true);
+            return json_decode($response, true) ?? [];
         }
 
         $message = '';
@@ -143,11 +109,6 @@ abstract class AbstractClient
         }
 
         throw new RequestException($message, $httpStatus, $response, $ch);
-    }
-
-    protected function isSandbox(): bool
-    {
-        return $this->getEnvironment() === MontonioClient::ENVIRONMENT_SANDBOX;
     }
 
     protected function getAccessKey(): string

--- a/src/Clients/OrdersClient.php
+++ b/src/Clients/OrdersClient.php
@@ -6,7 +6,7 @@ namespace Montonio\Clients;
 
 use Montonio\Structs\OrderData;
 
-class OrdersClient extends AbstractClient
+class OrdersClient extends PaymentsAbstractClient
 {
     public function createOrder(OrderData $paymentData): array
     {

--- a/src/Clients/PaymentIntentsClient.php
+++ b/src/Clients/PaymentIntentsClient.php
@@ -6,7 +6,7 @@ namespace Montonio\Clients;
 
 use Montonio\Structs\CreatePaymentIntentDraftData;
 
-class PaymentIntentsClient extends AbstractClient
+class PaymentIntentsClient extends PaymentsAbstractClient
 {
     public function createDraft(CreatePaymentIntentDraftData $data): array
     {

--- a/src/Clients/PaymentLinksClient.php
+++ b/src/Clients/PaymentLinksClient.php
@@ -6,7 +6,7 @@ namespace Montonio\Clients;
 
 use Montonio\Structs\CreatePaymentLinkData;
 
-class PaymentLinksClient extends AbstractClient
+class PaymentLinksClient extends PaymentsAbstractClient
 {
     public function createPaymentLink(CreatePaymentLinkData $data): array
     {

--- a/src/Clients/PaymentsAbstractClient.php
+++ b/src/Clients/PaymentsAbstractClient.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Clients;
+
+use Montonio\MontonioClient;
+
+abstract class PaymentsAbstractClient extends AbstractClient
+{
+    protected const SANDBOX_URL = 'https://sandbox-stargate.montonio.com/api';
+    protected const LIVE_URL = 'https://stargate.montonio.com/api';
+
+    protected function get(string $url, array $params = []): array
+    {
+        return $this->call(
+            'GET',
+            $this->getUrl($url),
+            null,
+            [
+                'Content-Type: application/json',
+                'Authorization: Bearer ' . $this->generateToken(),
+            ],
+        );
+    }
+
+    protected function post(string $url, array $payload = []): array
+    {
+        return $this->call(
+            'POST',
+            $this->getUrl($url),
+            json_encode(['data' => $this->generateToken($payload)]),
+            ['Content-Type: application/json'],
+        );
+    }
+
+    protected function getUrl(string $path): string
+    {
+        return ($this->isSandbox() ? static::SANDBOX_URL : static::LIVE_URL)
+            . (str_starts_with($path, '/') ? '' : '/')
+            . $path;
+    }
+
+    protected function isSandbox(): bool
+    {
+        return $this->getEnvironment() === MontonioClient::ENVIRONMENT_SANDBOX;
+    }
+}

--- a/src/Clients/PayoutsClient.php
+++ b/src/Clients/PayoutsClient.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Montonio\Clients;
 
-class PayoutsClient extends AbstractClient
+class PayoutsClient extends PaymentsAbstractClient
 {
     /**
      * List payouts for a store.

--- a/src/Clients/RefundsClient.php
+++ b/src/Clients/RefundsClient.php
@@ -6,7 +6,7 @@ namespace Montonio\Clients;
 
 use Montonio\Structs\CreateRefundData;
 
-class RefundsClient extends AbstractClient
+class RefundsClient extends PaymentsAbstractClient
 {
     public function createRefund(CreateRefundData $data): array
     {

--- a/src/Clients/SessionsClient.php
+++ b/src/Clients/SessionsClient.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Montonio\Clients;
 
-class SessionsClient extends AbstractClient
+class SessionsClient extends PaymentsAbstractClient
 {
     /**
      * Create a session for embedded card payments.

--- a/src/Clients/StoresClient.php
+++ b/src/Clients/StoresClient.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Montonio\Clients;
 
-class StoresClient extends AbstractClient
+class StoresClient extends PaymentsAbstractClient
 {
     public function getPaymentMethods(): array
     {

--- a/src/MontonioClient.php
+++ b/src/MontonioClient.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Montonio;
 
-use Montonio\Clients\AbstractClient;
 use Montonio\Clients\OrdersClient;
+use Montonio\Clients\PaymentsAbstractClient;
 use Montonio\Clients\PaymentIntentsClient;
 use Montonio\Clients\PaymentLinksClient;
 use Montonio\Clients\PayoutsClient;
@@ -13,7 +13,7 @@ use Montonio\Clients\RefundsClient;
 use Montonio\Clients\SessionsClient;
 use Montonio\Clients\StoresClient;
 
-class MontonioClient extends AbstractClient
+class MontonioClient extends PaymentsAbstractClient
 {
     public const ENVIRONMENT_SANDBOX = 'sandbox';
     public const ENVIRONMENT_LIVE = 'live';


### PR DESCRIPTION
## Summary
- Split AbstractClient into shared base + PaymentsAbstractClient
- Payments clients now extend PaymentsAbstractClient (no public API changes)
- Added `?? []` null safety in execute() for future 204 No Content support