### PR TITLE
feat: add Montonio Shipping V2 API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/makstech/montonio-php-sdk?style=flat-square&label=downloads)](https://packagist.org/packages/makstech/montonio-php-sdk)
 [![Codecov](https://img.shields.io/codecov/c/github/makstech/montonio-php-sdk?style=flat-square)](https://app.codecov.io/gh/makstech/montonio-php-sdk)
 
-PHP SDK for the [Montonio Stargate API](https://docs.montonio.com/api/stargate/). Wraps the API with fluent struct builders and JWT-authenticated requests.
+PHP SDK for the [Montonio Stargate API](https://docs.montonio.com/api/stargate/) and [Shipping V2 API](https://docs.montonio.com/api/shipping-v2/reference). Wraps both APIs with fluent struct builders and JWT-authenticated requests.
 
 ## Features
 
@@ -17,6 +17,11 @@ PHP SDK for the [Montonio Stargate API](https://docs.montonio.com/api/stargate/)
 | **Sessions** | `createSession` | [Embedded cards guide](https://docs.montonio.com/api/stargate/guides/embedded-cards) |
 | **Payouts** | `getPayouts`, `exportPayout`, `getBalances` | [Payouts guide](https://docs.montonio.com/api/stargate/guides/payouts) |
 | **Stores** | `getPaymentMethods` | [Payment methods guide](https://docs.montonio.com/api/stargate/guides/payment-methods) |
+| **Shipping / Carriers** | `getCarriers` | [Shipping API reference](https://docs.montonio.com/api/shipping-v2/reference) |
+| **Shipping / Methods** | `getShippingMethods`, `getPickupPoints`, `getCourierServices`, `filterByParcels`, `getRates` | [Shipping methods guide](https://docs.montonio.com/api/shipping-v2/guides/shipping-methods) |
+| **Shipping / Shipments** | `createShipment`, `updateShipment`, `getShipment` | [Shipments guide](https://docs.montonio.com/api/shipping-v2/guides/shipments) |
+| **Shipping / Labels** | `createLabelFile`, `getLabelFile` | [Labels guide](https://docs.montonio.com/api/shipping-v2/guides/labels) |
+| **Shipping / Webhooks** | `createWebhook`, `listWebhooks`, `deleteWebhook` | [Webhooks guide](https://docs.montonio.com/api/shipping-v2/guides/webhooks) |
 
 Supported payment methods: bank payments, card payments (Apple Pay, Google Pay), BLIK, Buy Now Pay Later, and Hire Purchase.
 
@@ -218,6 +223,135 @@ $payouts = $client->payouts()->getPayouts($storeUuid, limit: 50, offset: 0, orde
 $export = $client->payouts()->exportPayout($storeUuid, $payoutUuid, 'excel');
 $downloadUrl = $export['url'];
 ```
+
+## Shipping
+
+All shipping sub-clients are accessed via `$client->shipping()`:
+
+### Carriers
+
+```php
+$carriers = $client->shipping()->carriers()->getCarriers();
+```
+
+### Shipping Methods
+
+```php
+// All shipping methods
+$methods = $client->shipping()->shippingMethods()->getShippingMethods();
+
+// Pickup points for a carrier
+$pickupPoints = $client->shipping()->shippingMethods()
+    ->getPickupPoints('omniva', 'EE');
+
+// Courier services for a carrier
+$courierServices = $client->shipping()->shippingMethods()
+    ->getCourierServices('dpd', 'EE');
+
+// Filter methods by parcel dimensions
+$filtered = $client->shipping()->shippingMethods()->filterByParcels(
+    (new \Montonio\Structs\Shipping\FilterByParcelsData())
+        ->setParcels([
+            (new \Montonio\Structs\Shipping\ShipmentParcel())->setWeight(1.5),
+        ]),
+    'EE' // destination
+);
+
+// Calculate shipping rates
+$rates = $client->shipping()->shippingMethods()->getRates(
+    (new \Montonio\Structs\Shipping\ShippingRatesData())
+        ->setDestination('EE')
+        ->setParcels([
+            (new \Montonio\Structs\Shipping\RatesParcel())->setItems([
+                (new \Montonio\Structs\Shipping\RatesItem())
+                    ->setLength(20.0)
+                    ->setWidth(15.0)
+                    ->setHeight(10.0)
+                    ->setWeight(0.5),
+            ]),
+        ])
+);
+```
+
+### Shipments
+
+```php
+$shipment = $client->shipping()->shipments()->createShipment(
+    (new \Montonio\Structs\Shipping\CreateShipmentData())
+        ->setShippingMethod(
+            (new \Montonio\Structs\Shipping\ShipmentShippingMethod())
+                ->setType('pickupPoint')
+                ->setId($pickupPointId) // UUID from getPickupPoints()
+        )
+        ->setReceiver(
+            (new \Montonio\Structs\Shipping\ShippingContact())
+                ->setName('John Doe')
+                ->setPhoneCountryCode('372')
+                ->setPhoneNumber('53334770')
+                ->setEmail('john@example.com')
+        )
+        ->setParcels([
+            (new \Montonio\Structs\Shipping\ShipmentParcel())->setWeight(1.0),
+        ])
+        ->setMerchantReference('ORDER-123')
+);
+
+echo $shipment['id'];
+echo $shipment['status']; // 'pending', 'registered', etc.
+
+// Get shipment details
+$shipment = $client->shipping()->shipments()->getShipment($shipmentId);
+
+// Update a shipment
+$updated = $client->shipping()->shipments()->updateShipment($shipmentId,
+    (new \Montonio\Structs\Shipping\UpdateShipmentData())
+        ->setReceiver(
+            (new \Montonio\Structs\Shipping\ShippingContact())
+                ->setName('Jane Doe')
+                ->setPhoneCountryCode('372')
+                ->setPhoneNumber('55512345')
+        )
+);
+```
+
+### Label Files
+
+```php
+$labelFile = $client->shipping()->labels()->createLabelFile(
+    (new \Montonio\Structs\Shipping\CreateLabelFileData())
+        ->setShipmentIds([$shipmentId])
+        ->setPageSize('A4')
+        ->setSynchronous(true)
+);
+
+echo $labelFile['labelFileUrl']; // PDF download URL (expires in 5 minutes)
+
+// Get label file status
+$labelFile = $client->shipping()->labels()->getLabelFile($labelFileId);
+echo $labelFile['status']; // 'pending', 'ready', 'failed'
+```
+
+### Shipping Webhooks
+
+```php
+$webhook = $client->shipping()->webhooks()->createWebhook(
+    (new \Montonio\Structs\Shipping\CreateShippingWebhookData())
+        ->setUrl('https://myshop.com/shipping-webhook')
+        ->setEnabledEvents([
+            'shipment.registered',
+            'shipment.statusUpdated',
+            'labelFile.ready',
+        ])
+);
+
+// List all webhooks
+$webhooks = $client->shipping()->webhooks()->listWebhooks();
+
+// Delete a webhook
+$client->shipping()->webhooks()->deleteWebhook($webhookId);
+```
+
+See the [Shipping API reference](https://docs.montonio.com/api/shipping-v2/reference) for all available fields and response details.
 
 ## License
 

--- a/src/Clients/PaymentsAbstractClient.php
+++ b/src/Clients/PaymentsAbstractClient.php
@@ -6,6 +6,14 @@ namespace Montonio\Clients;
 
 use Montonio\MontonioClient;
 
+/**
+ * Base client for the Montonio Payments (Stargate) API.
+ *
+ * POST requests wrap the payload in a JWT token sent as {"data": "<token>"}.
+ * GET requests use a Bearer JWT in the Authorization header.
+ *
+ * @see https://docs.montonio.com/api/stargate/reference
+ */
 abstract class PaymentsAbstractClient extends AbstractClient
 {
     protected const SANDBOX_URL = 'https://sandbox-stargate.montonio.com/api';

--- a/src/Clients/PayoutsClient.php
+++ b/src/Clients/PayoutsClient.php
@@ -44,8 +44,6 @@ class PayoutsClient extends PaymentsAbstractClient
      * @param string $payoutUuid The payout UUID
      * @param string $format     Export format: 'excel' or 'xml'
      * @return array Contains 'url' with a pre-signed download link
-     *
-     * @codeCoverageIgnore Requires actual payouts in the sandbox which can't be created via API
      */
     public function exportPayout(string $storeUuid, string $payoutUuid, string $format = 'excel'): array
     {

--- a/src/Clients/Shipping/CarriersClient.php
+++ b/src/Clients/Shipping/CarriersClient.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Clients\Shipping;
+
+use Montonio\Clients\ShippingAbstractClient;
+
+/**
+ * @see https://docs.montonio.com/api/shipping-v2/reference#get-all-carriers
+ */
+class CarriersClient extends ShippingAbstractClient
+{
+    /**
+     * Fetch all carriers available through Montonio Shipping.
+     */
+    public function getCarriers(): array
+    {
+        return $this->get('carriers');
+    }
+}

--- a/src/Clients/Shipping/LabelFilesClient.php
+++ b/src/Clients/Shipping/LabelFilesClient.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Clients\Shipping;
+
+use Montonio\Clients\ShippingAbstractClient;
+use Montonio\Structs\Shipping\CreateLabelFileData;
+
+/**
+ * @see https://docs.montonio.com/api/shipping-v2/guides/labels
+ *
+ */
+class LabelFilesClient extends ShippingAbstractClient
+{
+    /**
+     * Create a label file for one or more shipments.
+     *
+     * Use synchronous: true to get the download URL in the response immediately.
+     * Label URLs expire after 5 minutes — use getLabelFile() to get a fresh URL.
+     */
+    public function createLabelFile(CreateLabelFileData $data): array
+    {
+        return $this->post('label-files', $data->toArray());
+    }
+
+    /**
+     * Get label file status and download URL. Use this to get a fresh URL after expiry.
+     */
+    public function getLabelFile(string $labelFileId): array
+    {
+        return $this->get('label-files/' . $labelFileId);
+    }
+}

--- a/src/Clients/Shipping/ShipmentsClient.php
+++ b/src/Clients/Shipping/ShipmentsClient.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Clients\Shipping;
+
+use Montonio\Clients\ShippingAbstractClient;
+use Montonio\Structs\Shipping\CreateShipmentData;
+use Montonio\Structs\Shipping\UpdateShipmentData;
+
+/**
+ * @see https://docs.montonio.com/api/shipping-v2/guides/shipments
+ *
+ */
+class ShipmentsClient extends ShippingAbstractClient
+{
+    /**
+     * Create a new shipment.
+     *
+     * Use synchronous: true to wait for carrier registration before the response.
+     */
+    public function createShipment(CreateShipmentData $data): array
+    {
+        return $this->post('shipments', $data->toArray());
+    }
+
+    /**
+     * Update an existing shipment (PATCH — only provided fields are changed).
+     */
+    public function updateShipment(string $shipmentId, UpdateShipmentData $data): array
+    {
+        return $this->patch('shipments/' . $shipmentId, $data->toArray());
+    }
+
+    public function getShipment(string $shipmentId): array
+    {
+        return $this->get('shipments/' . $shipmentId);
+    }
+}

--- a/src/Clients/Shipping/ShippingClient.php
+++ b/src/Clients/Shipping/ShippingClient.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Clients\Shipping;
+
+use Montonio\Clients\ShippingAbstractClient;
+
+/**
+ * Factory for Montonio Shipping V2 API sub-clients.
+ *
+ * Access via $client->shipping()->carriers(), ->shippingMethods(), etc.
+ *
+ * @see https://docs.montonio.com/api/shipping-v2/reference
+ */
+class ShippingClient extends ShippingAbstractClient
+{
+    public function carriers(): CarriersClient
+    {
+        return new CarriersClient(
+            $this->getAccessKey(),
+            $this->getSecretKey(),
+            $this->getEnvironment(),
+        );
+    }
+
+    public function shippingMethods(): ShippingMethodsClient
+    {
+        return new ShippingMethodsClient(
+            $this->getAccessKey(),
+            $this->getSecretKey(),
+            $this->getEnvironment(),
+        );
+    }
+
+    public function shipments(): ShipmentsClient
+    {
+        return new ShipmentsClient(
+            $this->getAccessKey(),
+            $this->getSecretKey(),
+            $this->getEnvironment(),
+        );
+    }
+
+    public function labels(): LabelFilesClient
+    {
+        return new LabelFilesClient(
+            $this->getAccessKey(),
+            $this->getSecretKey(),
+            $this->getEnvironment(),
+        );
+    }
+
+    public function webhooks(): ShippingWebhooksClient
+    {
+        return new ShippingWebhooksClient(
+            $this->getAccessKey(),
+            $this->getSecretKey(),
+            $this->getEnvironment(),
+        );
+    }
+}

--- a/src/Clients/Shipping/ShippingMethodsClient.php
+++ b/src/Clients/Shipping/ShippingMethodsClient.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Clients\Shipping;
+
+use Montonio\Clients\ShippingAbstractClient;
+use Montonio\Structs\Shipping\FilterByParcelsData;
+use Montonio\Structs\Shipping\ShippingRatesData;
+
+/**
+ * @see https://docs.montonio.com/api/shipping-v2/guides/shipping-methods
+ */
+class ShippingMethodsClient extends ShippingAbstractClient
+{
+    /**
+     * Fetch all shipping methods available for your store, grouped by country and carrier.
+     */
+    public function getShippingMethods(): array
+    {
+        return $this->get('shipping-methods');
+    }
+
+    /**
+     * Fetch pickup points (parcel machines, post offices, parcel shops) for a carrier and country.
+     *
+     * @param string      $carrierCode Carrier code (e.g. 'omniva', 'dpd')
+     * @param string      $countryCode ISO country code (e.g. 'EE', 'LT')
+     * @param string|null $type        Filter by type: 'parcelMachine', 'postOffice', or 'parcelShop'
+     */
+    public function getPickupPoints(string $carrierCode, string $countryCode, ?string $type = null): array
+    {
+        $params = [
+            'carrierCode' => $carrierCode,
+            'countryCode' => $countryCode,
+        ];
+
+        if ($type !== null) {
+            $params['type'] = $type;
+        }
+
+        return $this->get('shipping-methods/pickup-points', $params);
+    }
+
+    /**
+     * Fetch courier services for a carrier and country.
+     *
+     * @param string $carrierCode Carrier code (e.g. 'dpd', 'omniva')
+     * @param string $countryCode ISO country code (e.g. 'EE', 'LT')
+     */
+    public function getCourierServices(string $carrierCode, string $countryCode): array
+    {
+        return $this->get('shipping-methods/courier-services', [
+            'carrierCode' => $carrierCode,
+            'countryCode' => $countryCode,
+        ]);
+    }
+
+    /**
+     * Filter available shipping methods by parcel dimensions and destination.
+     *
+     * @param string      $destination Destination country code (e.g. 'EE')
+     * @param string|null $source      Source country code
+     */
+    public function filterByParcels(FilterByParcelsData $data, string $destination, ?string $source = null): array
+    {
+        $queryParams = ['destination' => $destination];
+
+        if ($source !== null) {
+            $queryParams['source'] = $source;
+        }
+
+        return $this->post('shipping-methods/filter-by-parcels', $data->toArray(), $queryParams);
+    }
+
+    /**
+     * Calculate shipping rates for given parcels and destination.
+     *
+     * Only returns rates for carriers with Montonio contracts.
+     *
+     * @param string|null $carrierCode        Filter by carrier code
+     * @param string|null $shippingMethodType Filter by type: 'courier' or 'pickupPoint'
+     */
+    public function getRates(ShippingRatesData $data, ?string $carrierCode = null, ?string $shippingMethodType = null): array
+    {
+        $queryParams = [];
+
+        if ($carrierCode !== null) {
+            $queryParams['carrierCode'] = $carrierCode;
+        }
+
+        if ($shippingMethodType !== null) {
+            $queryParams['shippingMethodType'] = $shippingMethodType;
+        }
+
+        return $this->post('shipping-methods/rates', $data->toArray(), $queryParams);
+    }
+}

--- a/src/Clients/Shipping/ShippingWebhooksClient.php
+++ b/src/Clients/Shipping/ShippingWebhooksClient.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Clients\Shipping;
+
+use Montonio\Clients\ShippingAbstractClient;
+use Montonio\Structs\Shipping\CreateShippingWebhookData;
+
+/**
+ * Manage shipping webhooks for receiving status updates.
+ *
+ * Maximum 10 webhooks per store.
+ *
+ * @see https://docs.montonio.com/api/shipping-v2/guides/webhooks
+ */
+class ShippingWebhooksClient extends ShippingAbstractClient
+{
+    /**
+     * Create a webhook to subscribe to shipping events.
+     *
+     * Available events: shipment.registered, shipment.registrationFailed,
+     * shipment.labelsCreated, shipment.statusUpdated, labelFile.ready, labelFile.creationFailed
+     */
+    public function createWebhook(CreateShippingWebhookData $data): array
+    {
+        return $this->post('webhooks', $data->toArray());
+    }
+
+    public function listWebhooks(): array
+    {
+        return $this->get('webhooks');
+    }
+
+    public function deleteWebhook(string $webhookId): array
+    {
+        return $this->delete('webhooks/' . $webhookId);
+    }
+}

--- a/src/Clients/ShippingAbstractClient.php
+++ b/src/Clients/ShippingAbstractClient.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Clients;
+
+use Montonio\MontonioClient;
+
+/**
+ * Base client for the Montonio Shipping V2 API.
+ *
+ * Unlike the Payments (Stargate) API, all Shipping requests use Bearer JWT auth
+ * and send plain JSON bodies (not JWT-wrapped).
+ *
+ * @see https://docs.montonio.com/api/shipping-v2/reference
+ */
+abstract class ShippingAbstractClient extends AbstractClient
+{
+    protected const SANDBOX_URL = 'https://sandbox-shipping.montonio.com/api/v2';
+    protected const LIVE_URL = 'https://shipping.montonio.com/api/v2';
+
+    protected function get(string $url, array $queryParams = []): array
+    {
+        $fullUrl = $this->getUrl($url);
+
+        if (!empty($queryParams)) {
+            $fullUrl .= '?' . http_build_query($queryParams);
+        }
+
+        return $this->call(
+            'GET',
+            $fullUrl,
+            null,
+            [
+                'Content-Type: application/json',
+                'Authorization: Bearer ' . $this->generateToken(),
+            ],
+        );
+    }
+
+    protected function post(string $url, array $payload = [], array $queryParams = []): array
+    {
+        $fullUrl = $this->getUrl($url);
+
+        if (!empty($queryParams)) {
+            $fullUrl .= '?' . http_build_query($queryParams);
+        }
+
+        return $this->call(
+            'POST',
+            $fullUrl,
+            json_encode($payload),
+            [
+                'Content-Type: application/json',
+                'Authorization: Bearer ' . $this->generateToken(),
+            ],
+        );
+    }
+
+    protected function patch(string $url, array $payload = []): array
+    {
+        return $this->call(
+            'PATCH',
+            $this->getUrl($url),
+            json_encode($payload),
+            [
+                'Content-Type: application/json',
+                'Authorization: Bearer ' . $this->generateToken(),
+            ],
+        );
+    }
+
+    protected function delete(string $url): array
+    {
+        return $this->call(
+            'DELETE',
+            $this->getUrl($url),
+            null,
+            [
+                'Content-Type: application/json',
+                'Authorization: Bearer ' . $this->generateToken(),
+            ],
+        );
+    }
+
+    protected function getUrl(string $path): string
+    {
+        return ($this->isSandbox() ? static::SANDBOX_URL : static::LIVE_URL)
+            . (str_starts_with($path, '/') ? '' : '/')
+            . $path;
+    }
+
+    protected function isSandbox(): bool
+    {
+        return $this->getEnvironment() === MontonioClient::ENVIRONMENT_SANDBOX;
+    }
+}

--- a/src/MontonioClient.php
+++ b/src/MontonioClient.php
@@ -6,6 +6,7 @@ namespace Montonio;
 
 use Montonio\Clients\OrdersClient;
 use Montonio\Clients\PaymentsAbstractClient;
+use Montonio\Clients\Shipping\ShippingClient;
 use Montonio\Clients\PaymentIntentsClient;
 use Montonio\Clients\PaymentLinksClient;
 use Montonio\Clients\PayoutsClient;
@@ -75,6 +76,15 @@ class MontonioClient extends PaymentsAbstractClient
     public function stores(): StoresClient
     {
         return new StoresClient(
+            $this->getAccessKey(),
+            $this->getSecretKey(),
+            $this->getEnvironment(),
+        );
+    }
+
+    public function shipping(): ShippingClient
+    {
+        return new ShippingClient(
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),

--- a/src/Structs/Shipping/AdditionalService.php
+++ b/src/Structs/Shipping/AdditionalService.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Structs\Shipping;
+
+use Montonio\Structs\AbstractStruct;
+
+class AdditionalService extends AbstractStruct
+{
+    protected string $code;
+    protected AdditionalServiceParams $params;
+
+    public function getCode(): ?string
+    {
+        return $this->code ?? null;
+    }
+
+    public function setCode(string $code): self
+    {
+        $this->code = $code;
+
+        return $this;
+    }
+
+    public function getParams(): ?AdditionalServiceParams
+    {
+        return $this->params ?? null;
+    }
+
+    public function setParams(AdditionalServiceParams $params): self
+    {
+        $this->params = $params;
+
+        return $this;
+    }
+}

--- a/src/Structs/Shipping/AdditionalServiceParams.php
+++ b/src/Structs/Shipping/AdditionalServiceParams.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Structs\Shipping;
+
+use Montonio\Structs\AbstractStruct;
+
+class AdditionalServiceParams extends AbstractStruct
+{
+    protected float $amount;
+
+    public function getAmount(): ?float
+    {
+        return $this->amount ?? null;
+    }
+
+    public function setAmount(float $amount): self
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+}

--- a/src/Structs/Shipping/CreateLabelFileData.php
+++ b/src/Structs/Shipping/CreateLabelFileData.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Structs\Shipping;
+
+use Montonio\Structs\AbstractStruct;
+
+/**
+ * Request data for creating a label file.
+ *
+ * @see https://docs.montonio.com/api/shipping-v2/reference#create-a-label-file
+ */
+class CreateLabelFileData extends AbstractStruct
+{
+    /** @var string[] */
+    protected array $shipmentIds = [];
+    protected string $pageSize;
+    protected int $labelsPerPage;
+    protected string $orderLabelsBy;
+    protected bool $synchronous;
+
+    public function getShipmentIds(): ?array
+    {
+        return $this->shipmentIds ?? null;
+    }
+
+    /**
+     * @param string[] $shipmentIds
+     */
+    public function setShipmentIds(array $shipmentIds): self
+    {
+        $this->shipmentIds = $shipmentIds;
+
+        return $this;
+    }
+
+    public function getPageSize(): ?string
+    {
+        return $this->pageSize ?? null;
+    }
+
+    public function setPageSize(string $pageSize): self
+    {
+        $this->pageSize = $pageSize;
+
+        return $this;
+    }
+
+    public function getLabelsPerPage(): ?int
+    {
+        return $this->labelsPerPage ?? null;
+    }
+
+    public function setLabelsPerPage(int $labelsPerPage): self
+    {
+        $this->labelsPerPage = $labelsPerPage;
+
+        return $this;
+    }
+
+    public function getOrderLabelsBy(): ?string
+    {
+        return $this->orderLabelsBy ?? null;
+    }
+
+    public function setOrderLabelsBy(string $orderLabelsBy): self
+    {
+        $this->orderLabelsBy = $orderLabelsBy;
+
+        return $this;
+    }
+
+    public function getSynchronous(): ?bool
+    {
+        return $this->synchronous ?? null;
+    }
+
+    public function setSynchronous(bool $synchronous): self
+    {
+        $this->synchronous = $synchronous;
+
+        return $this;
+    }
+}

--- a/src/Structs/Shipping/CreateShipmentData.php
+++ b/src/Structs/Shipping/CreateShipmentData.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Structs\Shipping;
+
+use Montonio\Structs\AbstractStruct;
+
+/**
+ * Request data for creating a shipment.
+ *
+ * @see https://docs.montonio.com/api/shipping-v2/reference#create-shipment
+ */
+class CreateShipmentData extends AbstractStruct
+{
+    protected ShipmentShippingMethod $shippingMethod;
+    protected ShippingContact $receiver;
+    protected ShippingContact $sender;
+    /** @var ShipmentParcel[] */
+    protected array $parcels = [];
+    /** @var ShipmentProduct[] */
+    protected array $products = [];
+    protected string $merchantReference;
+    protected string $montonioOrderUuid;
+    protected string $orderComment;
+    protected bool $synchronous;
+
+    public function getShippingMethod(): ?ShipmentShippingMethod
+    {
+        return $this->shippingMethod ?? null;
+    }
+
+    public function setShippingMethod(ShipmentShippingMethod $shippingMethod): self
+    {
+        $this->shippingMethod = $shippingMethod;
+
+        return $this;
+    }
+
+    public function getReceiver(): ?ShippingContact
+    {
+        return $this->receiver ?? null;
+    }
+
+    public function setReceiver(ShippingContact $receiver): self
+    {
+        $this->receiver = $receiver;
+
+        return $this;
+    }
+
+    public function getSender(): ?ShippingContact
+    {
+        return $this->sender ?? null;
+    }
+
+    public function setSender(ShippingContact $sender): self
+    {
+        $this->sender = $sender;
+
+        return $this;
+    }
+
+    public function getParcels(): ?array
+    {
+        return $this->parcels ?? null;
+    }
+
+    /**
+     * @param ShipmentParcel[] $parcels
+     */
+    public function setParcels(array $parcels): self
+    {
+        foreach ($parcels as $key => $parcel) {
+            if (is_array($parcel)) {
+                $parcels[$key] = new ShipmentParcel($parcel);
+            }
+        }
+
+        $this->parcels = $parcels;
+
+        return $this;
+    }
+
+    public function getProducts(): ?array
+    {
+        return $this->products ?? null;
+    }
+
+    /**
+     * @param ShipmentProduct[] $products
+     */
+    public function setProducts(array $products): self
+    {
+        foreach ($products as $key => $product) {
+            if (is_array($product)) {
+                $products[$key] = new ShipmentProduct($product);
+            }
+        }
+
+        $this->products = $products;
+
+        return $this;
+    }
+
+    public function getMerchantReference(): ?string
+    {
+        return $this->merchantReference ?? null;
+    }
+
+    public function setMerchantReference(string $merchantReference): self
+    {
+        $this->merchantReference = $merchantReference;
+
+        return $this;
+    }
+
+    public function getMontonioOrderUuid(): ?string
+    {
+        return $this->montonioOrderUuid ?? null;
+    }
+
+    public function setMontonioOrderUuid(string $montonioOrderUuid): self
+    {
+        $this->montonioOrderUuid = $montonioOrderUuid;
+
+        return $this;
+    }
+
+    public function getOrderComment(): ?string
+    {
+        return $this->orderComment ?? null;
+    }
+
+    public function setOrderComment(string $orderComment): self
+    {
+        $this->orderComment = $orderComment;
+
+        return $this;
+    }
+
+    public function getSynchronous(): ?bool
+    {
+        return $this->synchronous ?? null;
+    }
+
+    public function setSynchronous(bool $synchronous): self
+    {
+        $this->synchronous = $synchronous;
+
+        return $this;
+    }
+}

--- a/src/Structs/Shipping/CreateShippingWebhookData.php
+++ b/src/Structs/Shipping/CreateShippingWebhookData.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Structs\Shipping;
+
+use Montonio\Structs\AbstractStruct;
+
+/**
+ * Request data for creating a shipping webhook.
+ *
+ * @see https://docs.montonio.com/api/shipping-v2/reference#create-webhooks
+ */
+class CreateShippingWebhookData extends AbstractStruct
+{
+    protected string $url;
+    /** @var string[] */
+    protected array $enabledEvents = [];
+
+    public function getUrl(): ?string
+    {
+        return $this->url ?? null;
+    }
+
+    public function setUrl(string $url): self
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    public function getEnabledEvents(): ?array
+    {
+        return $this->enabledEvents ?? null;
+    }
+
+    /**
+     * @param string[] $enabledEvents
+     */
+    public function setEnabledEvents(array $enabledEvents): self
+    {
+        $this->enabledEvents = $enabledEvents;
+
+        return $this;
+    }
+}

--- a/src/Structs/Shipping/FilterByParcelsData.php
+++ b/src/Structs/Shipping/FilterByParcelsData.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Structs\Shipping;
+
+use Montonio\Structs\AbstractStruct;
+
+/**
+ * Request data for filtering shipping methods by parcel dimensions.
+ *
+ * @see https://docs.montonio.com/api/shipping-v2/reference#get-possible-shipping-methods-for-given-parcels
+ */
+class FilterByParcelsData extends AbstractStruct
+{
+    /** @var ShipmentParcel[] */
+    protected array $parcels = [];
+
+    public function getParcels(): ?array
+    {
+        return $this->parcels ?? null;
+    }
+
+    /**
+     * @param ShipmentParcel[] $parcels
+     */
+    public function setParcels(array $parcels): self
+    {
+        foreach ($parcels as $key => $parcel) {
+            if (is_array($parcel)) {
+                $parcels[$key] = new ShipmentParcel($parcel);
+            }
+        }
+
+        $this->parcels = $parcels;
+
+        return $this;
+    }
+}

--- a/src/Structs/Shipping/RatesItem.php
+++ b/src/Structs/Shipping/RatesItem.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Structs\Shipping;
+
+use Montonio\Structs\AbstractStruct;
+
+class RatesItem extends AbstractStruct
+{
+    protected float $length;
+    protected float $width;
+    protected float $height;
+    protected float $weight;
+    protected string $dimensionUnit;
+    protected string $weightUnit;
+    protected int $quantity;
+
+    public function getLength(): ?float
+    {
+        return $this->length ?? null;
+    }
+
+    public function setLength(float $length): self
+    {
+        $this->length = $length;
+
+        return $this;
+    }
+
+    public function getWidth(): ?float
+    {
+        return $this->width ?? null;
+    }
+
+    public function setWidth(float $width): self
+    {
+        $this->width = $width;
+
+        return $this;
+    }
+
+    public function getHeight(): ?float
+    {
+        return $this->height ?? null;
+    }
+
+    public function setHeight(float $height): self
+    {
+        $this->height = $height;
+
+        return $this;
+    }
+
+    public function getWeight(): ?float
+    {
+        return $this->weight ?? null;
+    }
+
+    public function setWeight(float $weight): self
+    {
+        $this->weight = $weight;
+
+        return $this;
+    }
+
+    public function getDimensionUnit(): ?string
+    {
+        return $this->dimensionUnit ?? null;
+    }
+
+    public function setDimensionUnit(string $dimensionUnit): self
+    {
+        $this->dimensionUnit = $dimensionUnit;
+
+        return $this;
+    }
+
+    public function getWeightUnit(): ?string
+    {
+        return $this->weightUnit ?? null;
+    }
+
+    public function setWeightUnit(string $weightUnit): self
+    {
+        $this->weightUnit = $weightUnit;
+
+        return $this;
+    }
+
+    public function getQuantity(): ?int
+    {
+        return $this->quantity ?? null;
+    }
+
+    public function setQuantity(int $quantity): self
+    {
+        $this->quantity = $quantity;
+
+        return $this;
+    }
+}

--- a/src/Structs/Shipping/RatesParcel.php
+++ b/src/Structs/Shipping/RatesParcel.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Structs\Shipping;
+
+use Montonio\Structs\AbstractStruct;
+
+class RatesParcel extends AbstractStruct
+{
+    /** @var RatesItem[] */
+    protected array $items = [];
+
+    public function getItems(): ?array
+    {
+        return $this->items ?? null;
+    }
+
+    /**
+     * @param RatesItem[] $items
+     */
+    public function setItems(array $items): self
+    {
+        foreach ($items as $key => $item) {
+            if (is_array($item)) {
+                $items[$key] = new RatesItem($item);
+            }
+        }
+
+        $this->items = $items;
+
+        return $this;
+    }
+}

--- a/src/Structs/Shipping/ShipmentParcel.php
+++ b/src/Structs/Shipping/ShipmentParcel.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Structs\Shipping;
+
+use Montonio\Structs\AbstractStruct;
+
+class ShipmentParcel extends AbstractStruct
+{
+    protected float $weight;
+    protected float $height;
+    protected float $width;
+    protected float $length;
+
+    public function getWeight(): ?float
+    {
+        return $this->weight ?? null;
+    }
+
+    public function setWeight(float $weight): self
+    {
+        $this->weight = $weight;
+
+        return $this;
+    }
+
+    public function getHeight(): ?float
+    {
+        return $this->height ?? null;
+    }
+
+    public function setHeight(float $height): self
+    {
+        $this->height = $height;
+
+        return $this;
+    }
+
+    public function getWidth(): ?float
+    {
+        return $this->width ?? null;
+    }
+
+    public function setWidth(float $width): self
+    {
+        $this->width = $width;
+
+        return $this;
+    }
+
+    public function getLength(): ?float
+    {
+        return $this->length ?? null;
+    }
+
+    public function setLength(float $length): self
+    {
+        $this->length = $length;
+
+        return $this;
+    }
+}

--- a/src/Structs/Shipping/ShipmentProduct.php
+++ b/src/Structs/Shipping/ShipmentProduct.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Structs\Shipping;
+
+use Montonio\Structs\AbstractStruct;
+
+class ShipmentProduct extends AbstractStruct
+{
+    protected string $sku;
+    protected string $name;
+    protected float $quantity;
+    protected string $barcode;
+    protected float $price;
+    protected string $currency;
+    protected array $attributes;
+    protected string $imageUrl;
+    protected string $storeProductUrl;
+    protected string $description;
+
+    public function getSku(): ?string
+    {
+        return $this->sku ?? null;
+    }
+
+    public function setSku(string $sku): self
+    {
+        $this->sku = $sku;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name ?? null;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getQuantity(): ?float
+    {
+        return $this->quantity ?? null;
+    }
+
+    public function setQuantity(float $quantity): self
+    {
+        $this->quantity = $quantity;
+
+        return $this;
+    }
+
+    public function getBarcode(): ?string
+    {
+        return $this->barcode ?? null;
+    }
+
+    public function setBarcode(string $barcode): self
+    {
+        $this->barcode = $barcode;
+
+        return $this;
+    }
+
+    public function getPrice(): ?float
+    {
+        return $this->price ?? null;
+    }
+
+    public function setPrice(float $price): self
+    {
+        $this->price = $price;
+
+        return $this;
+    }
+
+    public function getCurrency(): ?string
+    {
+        return $this->currency ?? null;
+    }
+
+    public function setCurrency(string $currency): self
+    {
+        $this->currency = $currency;
+
+        return $this;
+    }
+
+    public function getAttributes(): ?array
+    {
+        return $this->attributes ?? null;
+    }
+
+    public function setAttributes(array $attributes): self
+    {
+        $this->attributes = $attributes;
+
+        return $this;
+    }
+
+    public function getImageUrl(): ?string
+    {
+        return $this->imageUrl ?? null;
+    }
+
+    public function setImageUrl(string $imageUrl): self
+    {
+        $this->imageUrl = $imageUrl;
+
+        return $this;
+    }
+
+    public function getStoreProductUrl(): ?string
+    {
+        return $this->storeProductUrl ?? null;
+    }
+
+    public function setStoreProductUrl(string $storeProductUrl): self
+    {
+        $this->storeProductUrl = $storeProductUrl;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description ?? null;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+}

--- a/src/Structs/Shipping/ShipmentShippingMethod.php
+++ b/src/Structs/Shipping/ShipmentShippingMethod.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Structs\Shipping;
+
+use Montonio\Structs\AbstractStruct;
+
+class ShipmentShippingMethod extends AbstractStruct
+{
+    protected string $type;
+    protected string $id;
+    /** @var AdditionalService[] */
+    protected array $additionalServices = [];
+    protected string $parcelHandoverMethod;
+    protected string $lockerSize;
+
+    public function getType(): ?string
+    {
+        return $this->type ?? null;
+    }
+
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id ?? null;
+    }
+
+    public function setId(string $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getAdditionalServices(): ?array
+    {
+        return $this->additionalServices ?? null;
+    }
+
+    /**
+     * @param AdditionalService[] $additionalServices
+     */
+    public function setAdditionalServices(array $additionalServices): self
+    {
+        foreach ($additionalServices as $key => $service) {
+            if (is_array($service)) {
+                $additionalServices[$key] = new AdditionalService($service);
+            }
+        }
+
+        $this->additionalServices = $additionalServices;
+
+        return $this;
+    }
+
+    public function getParcelHandoverMethod(): ?string
+    {
+        return $this->parcelHandoverMethod ?? null;
+    }
+
+    public function setParcelHandoverMethod(string $parcelHandoverMethod): self
+    {
+        $this->parcelHandoverMethod = $parcelHandoverMethod;
+
+        return $this;
+    }
+
+    public function getLockerSize(): ?string
+    {
+        return $this->lockerSize ?? null;
+    }
+
+    public function setLockerSize(string $lockerSize): self
+    {
+        $this->lockerSize = $lockerSize;
+
+        return $this;
+    }
+}

--- a/src/Structs/Shipping/ShippingContact.php
+++ b/src/Structs/Shipping/ShippingContact.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Structs\Shipping;
+
+use Montonio\Structs\AbstractStruct;
+
+class ShippingContact extends AbstractStruct
+{
+    protected string $name;
+    protected string $phoneCountryCode;
+    protected string $phoneNumber;
+    protected string $firstName;
+    protected string $lastName;
+    protected string $streetAddress;
+    protected string $locality;
+    protected string $postalCode;
+    protected string $country;
+    protected string $region;
+    protected string $email;
+    protected string $companyName;
+
+    public function getName(): ?string
+    {
+        return $this->name ?? null;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getPhoneCountryCode(): ?string
+    {
+        return $this->phoneCountryCode ?? null;
+    }
+
+    public function setPhoneCountryCode(string $phoneCountryCode): self
+    {
+        $this->phoneCountryCode = $phoneCountryCode;
+
+        return $this;
+    }
+
+    public function getPhoneNumber(): ?string
+    {
+        return $this->phoneNumber ?? null;
+    }
+
+    public function setPhoneNumber(string $phoneNumber): self
+    {
+        $this->phoneNumber = $phoneNumber;
+
+        return $this;
+    }
+
+    public function getFirstName(): ?string
+    {
+        return $this->firstName ?? null;
+    }
+
+    public function setFirstName(string $firstName): self
+    {
+        $this->firstName = $firstName;
+
+        return $this;
+    }
+
+    public function getLastName(): ?string
+    {
+        return $this->lastName ?? null;
+    }
+
+    public function setLastName(string $lastName): self
+    {
+        $this->lastName = $lastName;
+
+        return $this;
+    }
+
+    public function getStreetAddress(): ?string
+    {
+        return $this->streetAddress ?? null;
+    }
+
+    public function setStreetAddress(string $streetAddress): self
+    {
+        $this->streetAddress = $streetAddress;
+
+        return $this;
+    }
+
+    public function getLocality(): ?string
+    {
+        return $this->locality ?? null;
+    }
+
+    public function setLocality(string $locality): self
+    {
+        $this->locality = $locality;
+
+        return $this;
+    }
+
+    public function getPostalCode(): ?string
+    {
+        return $this->postalCode ?? null;
+    }
+
+    public function setPostalCode(string $postalCode): self
+    {
+        $this->postalCode = $postalCode;
+
+        return $this;
+    }
+
+    public function getCountry(): ?string
+    {
+        return $this->country ?? null;
+    }
+
+    public function setCountry(string $country): self
+    {
+        $this->country = $country;
+
+        return $this;
+    }
+
+    public function getRegion(): ?string
+    {
+        return $this->region ?? null;
+    }
+
+    public function setRegion(string $region): self
+    {
+        $this->region = $region;
+
+        return $this;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email ?? null;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    public function getCompanyName(): ?string
+    {
+        return $this->companyName ?? null;
+    }
+
+    public function setCompanyName(string $companyName): self
+    {
+        $this->companyName = $companyName;
+
+        return $this;
+    }
+}

--- a/src/Structs/Shipping/ShippingRatesData.php
+++ b/src/Structs/Shipping/ShippingRatesData.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Structs\Shipping;
+
+use Montonio\Structs\AbstractStruct;
+
+/**
+ * Request data for calculating shipping rates.
+ *
+ * @see https://docs.montonio.com/api/shipping-v2/reference#calculate-shipping-rates
+ */
+class ShippingRatesData extends AbstractStruct
+{
+    protected string $destination;
+    /** @var RatesParcel[] */
+    protected array $parcels = [];
+
+    public function getDestination(): ?string
+    {
+        return $this->destination ?? null;
+    }
+
+    public function setDestination(string $destination): self
+    {
+        $this->destination = $destination;
+
+        return $this;
+    }
+
+    public function getParcels(): ?array
+    {
+        return $this->parcels ?? null;
+    }
+
+    /**
+     * @param RatesParcel[] $parcels
+     */
+    public function setParcels(array $parcels): self
+    {
+        foreach ($parcels as $key => $parcel) {
+            if (is_array($parcel)) {
+                $parcels[$key] = new RatesParcel($parcel);
+            }
+        }
+
+        $this->parcels = $parcels;
+
+        return $this;
+    }
+}

--- a/src/Structs/Shipping/UpdateShipmentData.php
+++ b/src/Structs/Shipping/UpdateShipmentData.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Structs\Shipping;
+
+use Montonio\Structs\AbstractStruct;
+
+/**
+ * Request data for updating a shipment (PATCH — all fields optional).
+ *
+ * @see https://docs.montonio.com/api/shipping-v2/reference#update-a-shipment
+ */
+class UpdateShipmentData extends AbstractStruct
+{
+    protected ShipmentShippingMethod $shippingMethod;
+    protected ShippingContact $receiver;
+    protected ShippingContact $sender;
+    /** @var ShipmentParcel[] */
+    protected array $parcels = [];
+
+    public function getShippingMethod(): ?ShipmentShippingMethod
+    {
+        return $this->shippingMethod ?? null;
+    }
+
+    public function setShippingMethod(ShipmentShippingMethod $shippingMethod): self
+    {
+        $this->shippingMethod = $shippingMethod;
+
+        return $this;
+    }
+
+    public function getReceiver(): ?ShippingContact
+    {
+        return $this->receiver ?? null;
+    }
+
+    public function setReceiver(ShippingContact $receiver): self
+    {
+        $this->receiver = $receiver;
+
+        return $this;
+    }
+
+    public function getSender(): ?ShippingContact
+    {
+        return $this->sender ?? null;
+    }
+
+    public function setSender(ShippingContact $sender): self
+    {
+        $this->sender = $sender;
+
+        return $this;
+    }
+
+    public function getParcels(): ?array
+    {
+        return $this->parcels ?? null;
+    }
+
+    /**
+     * @param ShipmentParcel[] $parcels
+     */
+    public function setParcels(array $parcels): self
+    {
+        foreach ($parcels as $key => $parcel) {
+            if (is_array($parcel)) {
+                $parcels[$key] = new ShipmentParcel($parcel);
+            }
+        }
+
+        $this->parcels = $parcels;
+
+        return $this;
+    }
+}

--- a/tests/Integration/Clients/Shipping/CarriersClientTest.php
+++ b/tests/Integration/Clients/Shipping/CarriersClientTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Clients\Shipping;
+
+use Tests\Integration\IntegrationTestCase;
+
+class CarriersClientTest extends IntegrationTestCase
+{
+    public function testGetCarriers(): void
+    {
+        $response = $this->getMontonioClient()->shipping()->carriers()->getCarriers();
+
+        $this->assertArrayHasKey('carriers', $response);
+        $this->assertIsArray($response['carriers']);
+    }
+}

--- a/tests/Integration/Clients/Shipping/LabelFilesClientTest.php
+++ b/tests/Integration/Clients/Shipping/LabelFilesClientTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Clients\Shipping;
+
+use Montonio\Exception\RequestException;
+use Montonio\Structs\Shipping\CreateLabelFileData;
+use Montonio\Structs\Shipping\CreateShipmentData;
+use Montonio\Structs\Shipping\ShipmentParcel;
+use Montonio\Structs\Shipping\ShipmentShippingMethod;
+use Montonio\Structs\Shipping\ShippingContact;
+use Tests\Integration\IntegrationTestCase;
+
+class LabelFilesClientTest extends IntegrationTestCase
+{
+    public function testCreateAndGetLabelFile(): void
+    {
+        $client = $this->getMontonioClient()->shipping();
+
+        // Get a pickup point ID
+        try {
+            $methods = $client->shippingMethods()->getShippingMethods();
+        } catch (RequestException $e) {
+            $this->markTestSkipped('Shipping methods not available in sandbox: ' . $e->getMessage());
+        }
+
+        $carrierCode = null;
+        $countryCode = null;
+
+        foreach ($methods['countries'] as $country) {
+            foreach ($country['carriers'] as $carrier) {
+                foreach ($carrier['shippingMethods'] as $method) {
+                    if ($method['type'] === 'pickupPoint') {
+                        $carrierCode = $carrier['carrierCode'];
+                        $countryCode = $country['countryCode'];
+                        break 3;
+                    }
+                }
+            }
+        }
+
+        if ($carrierCode === null) {
+            $this->markTestSkipped('No pickup point carriers available in sandbox.');
+        }
+
+        $pickupPoints = $client->shippingMethods()->getPickupPoints($carrierCode, $countryCode);
+
+        if (empty($pickupPoints['pickupPoints'])) {
+            $this->markTestSkipped('No pickup points available in sandbox.');
+        }
+
+        $pickupPointId = $pickupPoints['pickupPoints'][0]['id'];
+
+        // Create a shipment first
+        $shipment = $client->shipments()->createShipment(
+            (new CreateShipmentData())
+                ->setShippingMethod(
+                    (new ShipmentShippingMethod())
+                        ->setType('pickupPoint')
+                        ->setId($pickupPointId)
+                )
+                ->setReceiver(
+                    (new ShippingContact())
+                        ->setName('Label Test')
+                        ->setPhoneCountryCode('372')
+                        ->setPhoneNumber('53334770')
+                )
+                ->setParcels([
+                    (new ShipmentParcel())->setWeight(1.0),
+                ])
+                ->setMerchantReference('sdk-label-test-' . time())
+                ->setSynchronous(true)
+        );
+
+        // Create label file
+        $labelFile = $client->labels()->createLabelFile(
+            (new CreateLabelFileData())
+                ->setShipmentIds([$shipment['id']])
+                ->setPageSize('A4')
+                ->setSynchronous(true)
+        );
+
+        $this->assertArrayHasKey('id', $labelFile);
+        $this->assertArrayHasKey('status', $labelFile);
+
+        // Get label file
+        $fetched = $client->labels()->getLabelFile($labelFile['id']);
+
+        $this->assertSame($labelFile['id'], $fetched['id']);
+    }
+}

--- a/tests/Integration/Clients/Shipping/ShipmentsClientTest.php
+++ b/tests/Integration/Clients/Shipping/ShipmentsClientTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Clients\Shipping;
+
+use Montonio\Exception\RequestException;
+use Montonio\Structs\Shipping\CreateShipmentData;
+use Montonio\Structs\Shipping\ShipmentParcel;
+use Montonio\Structs\Shipping\ShipmentShippingMethod;
+use Montonio\Structs\Shipping\ShippingContact;
+use Montonio\Structs\Shipping\UpdateShipmentData;
+use Tests\Integration\IntegrationTestCase;
+
+class ShipmentsClientTest extends IntegrationTestCase
+{
+    private function findPickupPointIdOrSkip(): string
+    {
+        $client = $this->getMontonioClient()->shipping();
+
+        try {
+            $methods = $client->shippingMethods()->getShippingMethods();
+        } catch (RequestException $e) {
+            $this->markTestSkipped('Shipping methods not available in sandbox: ' . $e->getMessage());
+        }
+
+        $carrierCode = null;
+        $countryCode = null;
+
+        foreach ($methods['countries'] as $country) {
+            foreach ($country['carriers'] as $carrier) {
+                foreach ($carrier['shippingMethods'] as $method) {
+                    if ($method['type'] === 'pickupPoint') {
+                        $carrierCode = $carrier['carrierCode'];
+                        $countryCode = $country['countryCode'];
+                        break 3;
+                    }
+                }
+            }
+        }
+
+        if ($carrierCode === null) {
+            $this->markTestSkipped('No pickup point carriers available in sandbox.');
+        }
+
+        $pickupPoints = $client->shippingMethods()->getPickupPoints($carrierCode, $countryCode);
+
+        if (empty($pickupPoints['pickupPoints'])) {
+            $this->markTestSkipped('No pickup points available in sandbox.');
+        }
+
+        return $pickupPoints['pickupPoints'][0]['id'];
+    }
+
+    public function testCreateGetAndUpdateShipment(): void
+    {
+        $pickupPointId = $this->findPickupPointIdOrSkip();
+        $client = $this->getMontonioClient()->shipping();
+
+        // Create shipment
+        $data = (new CreateShipmentData())
+            ->setShippingMethod(
+                (new ShipmentShippingMethod())
+                    ->setType('pickupPoint')
+                    ->setId($pickupPointId)
+            )
+            ->setReceiver(
+                (new ShippingContact())
+                    ->setName('Test Receiver')
+                    ->setPhoneCountryCode('372')
+                    ->setPhoneNumber('53334770')
+                    ->setEmail('test@example.com')
+            )
+            ->setParcels([
+                (new ShipmentParcel())->setWeight(1.0),
+            ])
+            ->setMerchantReference('sdk-test-' . time());
+
+        $created = $client->shipments()->createShipment($data);
+
+        $this->assertArrayHasKey('id', $created);
+        $this->assertArrayHasKey('status', $created);
+
+        // Get shipment
+        $fetched = $client->shipments()->getShipment($created['id']);
+
+        $this->assertSame($created['id'], $fetched['id']);
+
+        // Update shipment
+        $updateData = (new UpdateShipmentData())
+            ->setReceiver(
+                (new ShippingContact())
+                    ->setName('Updated Receiver')
+                    ->setPhoneCountryCode('372')
+                    ->setPhoneNumber('53334770')
+            );
+
+        $updated = $client->shipments()->updateShipment($created['id'], $updateData);
+
+        $this->assertSame($created['id'], $updated['id']);
+    }
+}

--- a/tests/Integration/Clients/Shipping/ShippingMethodsClientTest.php
+++ b/tests/Integration/Clients/Shipping/ShippingMethodsClientTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Clients\Shipping;
+
+use Montonio\Exception\RequestException;
+use Montonio\Structs\Shipping\FilterByParcelsData;
+use Montonio\Structs\Shipping\RatesItem;
+use Montonio\Structs\Shipping\RatesParcel;
+use Montonio\Structs\Shipping\ShipmentParcel;
+use Montonio\Structs\Shipping\ShippingRatesData;
+use Tests\Integration\IntegrationTestCase;
+
+class ShippingMethodsClientTest extends IntegrationTestCase
+{
+    private function getShippingMethodsOrSkip(): array
+    {
+        try {
+            return $this->getMontonioClient()->shipping()->shippingMethods()->getShippingMethods();
+        } catch (RequestException $e) {
+            $this->markTestSkipped('Shipping methods not available in sandbox: ' . $e->getMessage());
+        }
+    }
+
+    public function testGetShippingMethods(): void
+    {
+        $response = $this->getShippingMethodsOrSkip();
+
+        $this->assertArrayHasKey('countries', $response);
+        $this->assertIsArray($response['countries']);
+    }
+
+    public function testGetPickupPoints(): void
+    {
+        $methods = $this->getShippingMethodsOrSkip();
+
+        $carrierCode = null;
+        $countryCode = null;
+
+        foreach ($methods['countries'] as $country) {
+            foreach ($country['carriers'] as $carrier) {
+                foreach ($carrier['shippingMethods'] as $method) {
+                    if ($method['type'] === 'pickupPoint') {
+                        $carrierCode = $carrier['carrierCode'];
+                        $countryCode = $country['countryCode'];
+                        break 3;
+                    }
+                }
+            }
+        }
+
+        if ($carrierCode === null) {
+            $this->markTestSkipped('No pickup point carriers available in sandbox.');
+        }
+
+        $response = $this->getMontonioClient()->shipping()->shippingMethods()
+            ->getPickupPoints($carrierCode, $countryCode);
+
+        $this->assertArrayHasKey('pickupPoints', $response);
+        $this->assertIsArray($response['pickupPoints']);
+    }
+
+    public function testGetCourierServices(): void
+    {
+        $methods = $this->getShippingMethodsOrSkip();
+
+        $carrierCode = null;
+        $countryCode = null;
+
+        foreach ($methods['countries'] as $country) {
+            foreach ($country['carriers'] as $carrier) {
+                foreach ($carrier['shippingMethods'] as $method) {
+                    if ($method['type'] === 'courier') {
+                        $carrierCode = $carrier['carrierCode'];
+                        $countryCode = $country['countryCode'];
+                        break 3;
+                    }
+                }
+            }
+        }
+
+        if ($carrierCode === null) {
+            $this->markTestSkipped('No courier carriers available in sandbox.');
+        }
+
+        $response = $this->getMontonioClient()->shipping()->shippingMethods()
+            ->getCourierServices($carrierCode, $countryCode);
+
+        $this->assertArrayHasKey('courierServices', $response);
+        $this->assertIsArray($response['courierServices']);
+    }
+
+    public function testFilterByParcels(): void
+    {
+        $data = (new FilterByParcelsData())
+            ->setParcels([
+                (new ShipmentParcel())->setWeight(1.0),
+            ]);
+
+        $response = $this->getMontonioClient()->shipping()->shippingMethods()
+            ->filterByParcels($data, 'EE');
+
+        $this->assertArrayHasKey('countries', $response);
+    }
+
+    public function testGetRates(): void
+    {
+        $data = (new ShippingRatesData())
+            ->setDestination('EE')
+            ->setParcels([
+                (new RatesParcel())->setItems([
+                    (new RatesItem())
+                        ->setLength(20.0)
+                        ->setWidth(15.0)
+                        ->setHeight(10.0)
+                        ->setWeight(0.5),
+                ]),
+            ]);
+
+        $response = $this->getMontonioClient()->shipping()->shippingMethods()
+            ->getRates($data);
+
+        $this->assertArrayHasKey('carriers', $response);
+        $this->assertArrayHasKey('destination', $response);
+    }
+}

--- a/tests/Integration/Clients/Shipping/ShippingWebhooksClientTest.php
+++ b/tests/Integration/Clients/Shipping/ShippingWebhooksClientTest.php
@@ -15,7 +15,7 @@ class ShippingWebhooksClientTest extends IntegrationTestCase
 
         // Create webhook
         $data = (new CreateShippingWebhookData())
-            ->setUrl('https://example.com/sdk-test-webhook-' . time())
+            ->setUrl('https://example.com/sdk-test-webhook-' . bin2hex(random_bytes(16)))
             ->setEnabledEvents(['shipment.registered']);
 
         $created = $client->createWebhook($data);

--- a/tests/Integration/Clients/Shipping/ShippingWebhooksClientTest.php
+++ b/tests/Integration/Clients/Shipping/ShippingWebhooksClientTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Clients\Shipping;
+
+use Montonio\Structs\Shipping\CreateShippingWebhookData;
+use Tests\Integration\IntegrationTestCase;
+
+class ShippingWebhooksClientTest extends IntegrationTestCase
+{
+    public function testCreateListAndDeleteWebhook(): void
+    {
+        $client = $this->getMontonioClient()->shipping()->webhooks();
+
+        // Create webhook
+        $data = (new CreateShippingWebhookData())
+            ->setUrl('https://example.com/sdk-test-webhook-' . time())
+            ->setEnabledEvents(['shipment.registered']);
+
+        $created = $client->createWebhook($data);
+
+        $this->assertArrayHasKey('id', $created);
+        $this->assertArrayHasKey('url', $created);
+        $this->assertArrayHasKey('enabledEvents', $created);
+
+        // List webhooks
+        $list = $client->listWebhooks();
+
+        $this->assertArrayHasKey('data', $list);
+        $this->assertIsArray($list['data']);
+
+        // Delete webhook (cleanup)
+        $client->deleteWebhook($created['id']);
+
+        // Verify deletion by listing again
+        $listAfter = $client->listWebhooks();
+        $ids = array_column($listAfter['data'], 'id');
+        $this->assertNotContains($created['id'], $ids);
+    }
+}

--- a/tests/Unit/Clients/PayoutsClientTest.php
+++ b/tests/Unit/Clients/PayoutsClientTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Clients;
+
+use Montonio\Clients\PayoutsClient;
+use Tests\BaseTestCase;
+
+class PayoutsClientTest extends BaseTestCase
+{
+    public function testExportPayout(): void
+    {
+        $mock = $this->getMockBuilder(PayoutsClient::class)
+            ->setConstructorArgs([ACCESS_KEY, SECRET_KEY, 'sandbox'])
+            ->onlyMethods(['call'])
+            ->getMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'GET',
+                $this->stringContains('/stores/store-uuid/payouts/payout-uuid/export-excel'),
+            )
+            ->willReturn(['url' => 'https://example.com/download.xlsx']);
+
+        $result = $mock->exportPayout('store-uuid', 'payout-uuid', 'excel');
+
+        $this->assertSame('https://example.com/download.xlsx', $result['url']);
+    }
+
+    public function testExportPayoutXml(): void
+    {
+        $mock = $this->getMockBuilder(PayoutsClient::class)
+            ->setConstructorArgs([ACCESS_KEY, SECRET_KEY, 'sandbox'])
+            ->onlyMethods(['call'])
+            ->getMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'GET',
+                $this->stringContains('/export-xml'),
+            )
+            ->willReturn(['url' => 'https://example.com/download.xml']);
+
+        $result = $mock->exportPayout('store-uuid', 'payout-uuid', 'xml');
+
+        $this->assertSame('https://example.com/download.xml', $result['url']);
+    }
+}

--- a/tests/Unit/Clients/Shipping/CarriersClientTest.php
+++ b/tests/Unit/Clients/Shipping/CarriersClientTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Clients\Shipping;
+
+use Montonio\Clients\Shipping\CarriersClient;
+use Tests\BaseTestCase;
+
+class CarriersClientTest extends BaseTestCase
+{
+    public function testGetCarriers(): void
+    {
+        $mock = $this->getMockBuilder(CarriersClient::class)
+            ->setConstructorArgs([ACCESS_KEY, SECRET_KEY, 'sandbox'])
+            ->onlyMethods(['call'])
+            ->getMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'GET',
+                $this->stringContains('/carriers'),
+                null,
+                $this->callback(fn ($headers) => is_array($headers))
+            )
+            ->willReturn(['carriers' => []]);
+
+        $result = $mock->getCarriers();
+
+        $this->assertSame(['carriers' => []], $result);
+    }
+}

--- a/tests/Unit/Clients/Shipping/LabelFilesClientTest.php
+++ b/tests/Unit/Clients/Shipping/LabelFilesClientTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Clients\Shipping;
+
+use Montonio\Clients\Shipping\LabelFilesClient;
+use Montonio\Structs\Shipping\CreateLabelFileData;
+use Tests\BaseTestCase;
+
+class LabelFilesClientTest extends BaseTestCase
+{
+    private function createClientMock(): LabelFilesClient
+    {
+        return $this->getMockBuilder(LabelFilesClient::class)
+            ->setConstructorArgs([ACCESS_KEY, SECRET_KEY, 'sandbox'])
+            ->onlyMethods(['call'])
+            ->getMock();
+    }
+
+    public function testCreateLabelFile(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'POST',
+                $this->stringContains('/label-files'),
+                $this->callback(function ($payload) {
+                    $data = json_decode($payload, true);
+                    return $data['shipmentIds'] === ['uuid-1']
+                        && $data['pageSize'] === 'A4';
+                }),
+            )
+            ->willReturn(['id' => 'label-uuid', 'status' => 'pending']);
+
+        $data = (new CreateLabelFileData())
+            ->setShipmentIds(['uuid-1'])
+            ->setPageSize('A4')
+            ->setSynchronous(true);
+
+        $result = $mock->createLabelFile($data);
+
+        $this->assertSame('label-uuid', $result['id']);
+    }
+
+    public function testGetLabelFile(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'GET',
+                $this->stringContains('/label-files/label-uuid'),
+            )
+            ->willReturn(['id' => 'label-uuid', 'status' => 'ready', 'labelFileUrl' => 'https://example.com/label.pdf']);
+
+        $result = $mock->getLabelFile('label-uuid');
+
+        $this->assertSame('ready', $result['status']);
+    }
+}

--- a/tests/Unit/Clients/Shipping/ShipmentsClientTest.php
+++ b/tests/Unit/Clients/Shipping/ShipmentsClientTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Clients\Shipping;
+
+use Montonio\Clients\Shipping\ShipmentsClient;
+use Montonio\Structs\Shipping\CreateShipmentData;
+use Montonio\Structs\Shipping\ShipmentParcel;
+use Montonio\Structs\Shipping\ShipmentShippingMethod;
+use Montonio\Structs\Shipping\ShippingContact;
+use Montonio\Structs\Shipping\UpdateShipmentData;
+use Tests\BaseTestCase;
+
+class ShipmentsClientTest extends BaseTestCase
+{
+    private function createClientMock(): ShipmentsClient
+    {
+        return $this->getMockBuilder(ShipmentsClient::class)
+            ->setConstructorArgs([ACCESS_KEY, SECRET_KEY, 'sandbox'])
+            ->onlyMethods(['call'])
+            ->getMock();
+    }
+
+    public function testCreateShipment(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'POST',
+                $this->stringContains('/shipments'),
+                $this->callback(function ($payload) {
+                    $data = json_decode($payload, true);
+                    return $data['shippingMethod']['type'] === 'pickupPoint'
+                        && $data['receiver']['name'] === 'Test';
+                }),
+            )
+            ->willReturn(['id' => 'shipment-uuid', 'status' => 'pending']);
+
+        $data = (new CreateShipmentData())
+            ->setShippingMethod(
+                (new ShipmentShippingMethod())->setType('pickupPoint')->setId('pp-123')
+            )
+            ->setReceiver(
+                (new ShippingContact())->setName('Test')->setPhoneCountryCode('372')->setPhoneNumber('555')
+            )
+            ->setParcels([(new ShipmentParcel())->setWeight(1.0)]);
+
+        $result = $mock->createShipment($data);
+
+        $this->assertSame('shipment-uuid', $result['id']);
+        $this->assertSame('pending', $result['status']);
+    }
+
+    public function testUpdateShipment(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'PATCH',
+                $this->stringContains('/shipments/shipment-uuid'),
+                $this->callback(function ($payload) {
+                    $data = json_decode($payload, true);
+                    return $data['receiver']['name'] === 'Updated';
+                }),
+            )
+            ->willReturn(['id' => 'shipment-uuid']);
+
+        $data = (new UpdateShipmentData())
+            ->setReceiver(
+                (new ShippingContact())->setName('Updated')->setPhoneCountryCode('372')->setPhoneNumber('555')
+            );
+
+        $result = $mock->updateShipment('shipment-uuid', $data);
+
+        $this->assertSame('shipment-uuid', $result['id']);
+    }
+
+    public function testGetShipment(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'GET',
+                $this->stringContains('/shipments/shipment-uuid'),
+            )
+            ->willReturn(['id' => 'shipment-uuid', 'status' => 'registered']);
+
+        $result = $mock->getShipment('shipment-uuid');
+
+        $this->assertSame('shipment-uuid', $result['id']);
+    }
+}

--- a/tests/Unit/Clients/Shipping/ShippingClientTest.php
+++ b/tests/Unit/Clients/Shipping/ShippingClientTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Clients\Shipping;
+
+use Montonio\Clients\Shipping\CarriersClient;
+use Montonio\Clients\Shipping\LabelFilesClient;
+use Montonio\Clients\Shipping\ShipmentsClient;
+use Montonio\Clients\Shipping\ShippingClient;
+use Montonio\Clients\Shipping\ShippingMethodsClient;
+use Montonio\Clients\Shipping\ShippingWebhooksClient;
+use Tests\BaseTestCase;
+
+class ShippingClientTest extends BaseTestCase
+{
+    public function testGetShippingClient(): void
+    {
+        $client = $this->getMontonioClient()->shipping();
+
+        $this->assertInstanceOf(ShippingClient::class, $client);
+    }
+
+    public function testGetCarriersClient(): void
+    {
+        $client = $this->getMontonioClient()->shipping()->carriers();
+
+        $this->assertInstanceOf(CarriersClient::class, $client);
+    }
+
+    public function testGetShippingMethodsClient(): void
+    {
+        $client = $this->getMontonioClient()->shipping()->shippingMethods();
+
+        $this->assertInstanceOf(ShippingMethodsClient::class, $client);
+    }
+
+    public function testGetShipmentsClient(): void
+    {
+        $client = $this->getMontonioClient()->shipping()->shipments();
+
+        $this->assertInstanceOf(ShipmentsClient::class, $client);
+    }
+
+    public function testGetLabelFilesClient(): void
+    {
+        $client = $this->getMontonioClient()->shipping()->labels();
+
+        $this->assertInstanceOf(LabelFilesClient::class, $client);
+    }
+
+    public function testGetShippingWebhooksClient(): void
+    {
+        $client = $this->getMontonioClient()->shipping()->webhooks();
+
+        $this->assertInstanceOf(ShippingWebhooksClient::class, $client);
+    }
+}

--- a/tests/Unit/Clients/Shipping/ShippingMethodsClientTest.php
+++ b/tests/Unit/Clients/Shipping/ShippingMethodsClientTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Clients\Shipping;
+
+use Montonio\Clients\Shipping\ShippingMethodsClient;
+use Montonio\Structs\Shipping\FilterByParcelsData;
+use Montonio\Structs\Shipping\RatesItem;
+use Montonio\Structs\Shipping\RatesParcel;
+use Montonio\Structs\Shipping\ShipmentParcel;
+use Montonio\Structs\Shipping\ShippingRatesData;
+use Tests\BaseTestCase;
+
+class ShippingMethodsClientTest extends BaseTestCase
+{
+    private function createClientMock(): ShippingMethodsClient
+    {
+        return $this->getMockBuilder(ShippingMethodsClient::class)
+            ->setConstructorArgs([ACCESS_KEY, SECRET_KEY, 'sandbox'])
+            ->onlyMethods(['call'])
+            ->getMock();
+    }
+
+    public function testGetShippingMethods(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'GET',
+                $this->stringContains('/shipping-methods'),
+            )
+            ->willReturn(['countries' => []]);
+
+        $result = $mock->getShippingMethods();
+
+        $this->assertSame(['countries' => []], $result);
+    }
+
+    public function testGetPickupPoints(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'GET',
+                $this->stringContains('/shipping-methods/pickup-points?carrierCode=omniva&countryCode=EE'),
+            )
+            ->willReturn(['pickupPoints' => []]);
+
+        $result = $mock->getPickupPoints('omniva', 'EE');
+
+        $this->assertSame(['pickupPoints' => []], $result);
+    }
+
+    public function testGetPickupPointsWithType(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'GET',
+                $this->stringContains('type=parcelMachine'),
+            )
+            ->willReturn(['pickupPoints' => []]);
+
+        $mock->getPickupPoints('omniva', 'EE', 'parcelMachine');
+    }
+
+    public function testGetCourierServices(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'GET',
+                $this->stringContains('/shipping-methods/courier-services?carrierCode=dpd&countryCode=EE'),
+            )
+            ->willReturn(['courierServices' => []]);
+
+        $result = $mock->getCourierServices('dpd', 'EE');
+
+        $this->assertSame(['courierServices' => []], $result);
+    }
+
+    public function testFilterByParcels(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'POST',
+                $this->stringContains('/shipping-methods/filter-by-parcels?destination=EE'),
+                $this->callback(function ($payload) {
+                    $data = json_decode($payload, true);
+                    return isset($data['parcels'][0]['weight']);
+                }),
+            )
+            ->willReturn(['countries' => []]);
+
+        $data = (new FilterByParcelsData())
+            ->setParcels([(new ShipmentParcel())->setWeight(1.0)]);
+
+        $result = $mock->filterByParcels($data, 'EE');
+
+        $this->assertSame(['countries' => []], $result);
+    }
+
+    public function testGetRates(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'POST',
+                $this->stringContains('/shipping-methods/rates'),
+                $this->callback(function ($payload) {
+                    $data = json_decode($payload, true);
+                    return $data['destination'] === 'EE';
+                }),
+            )
+            ->willReturn(['carriers' => [], 'destination' => 'EE']);
+
+        $data = (new ShippingRatesData())
+            ->setDestination('EE')
+            ->setParcels([
+                (new RatesParcel())->setItems([
+                    (new RatesItem())->setLength(20.0)->setWidth(15.0)->setHeight(10.0)->setWeight(0.5),
+                ]),
+            ]);
+
+        $result = $mock->getRates($data);
+
+        $this->assertSame('EE', $result['destination']);
+    }
+
+    public function testGetRatesWithQueryParams(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'POST',
+                $this->logicalAnd(
+                    $this->stringContains('carrierCode=omniva'),
+                    $this->stringContains('shippingMethodType=pickupPoint')
+                ),
+            )
+            ->willReturn(['carriers' => []]);
+
+        $data = (new ShippingRatesData())
+            ->setDestination('EE')
+            ->setParcels([
+                (new RatesParcel())->setItems([
+                    (new RatesItem())->setLength(10.0)->setWidth(5.0)->setHeight(3.0)->setWeight(1.0),
+                ]),
+            ]);
+
+        $mock->getRates($data, 'omniva', 'pickupPoint');
+    }
+}

--- a/tests/Unit/Clients/Shipping/ShippingMethodsClientTest.php
+++ b/tests/Unit/Clients/Shipping/ShippingMethodsClientTest.php
@@ -112,6 +112,27 @@ class ShippingMethodsClientTest extends BaseTestCase
         $this->assertSame(['countries' => []], $result);
     }
 
+    public function testFilterByParcelsWithSource(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'POST',
+                $this->logicalAnd(
+                    $this->stringContains('destination=EE'),
+                    $this->stringContains('source=LT')
+                ),
+            )
+            ->willReturn(['countries' => []]);
+
+        $data = (new FilterByParcelsData())
+            ->setParcels([(new ShipmentParcel())->setWeight(1.0)]);
+
+        $mock->filterByParcels($data, 'EE', 'LT');
+    }
+
     public function testGetRates(): void
     {
         $mock = $this->createClientMock();

--- a/tests/Unit/Clients/Shipping/ShippingWebhooksClientTest.php
+++ b/tests/Unit/Clients/Shipping/ShippingWebhooksClientTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Clients\Shipping;
+
+use Montonio\Clients\Shipping\ShippingWebhooksClient;
+use Montonio\Structs\Shipping\CreateShippingWebhookData;
+use Tests\BaseTestCase;
+
+class ShippingWebhooksClientTest extends BaseTestCase
+{
+    private function createClientMock(): ShippingWebhooksClient
+    {
+        return $this->getMockBuilder(ShippingWebhooksClient::class)
+            ->setConstructorArgs([ACCESS_KEY, SECRET_KEY, 'sandbox'])
+            ->onlyMethods(['call'])
+            ->getMock();
+    }
+
+    public function testCreateWebhook(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'POST',
+                $this->stringContains('/webhooks'),
+                $this->callback(function ($payload) {
+                    $data = json_decode($payload, true);
+                    return $data['url'] === 'https://example.com/hook'
+                        && $data['enabledEvents'] === ['shipment.registered'];
+                }),
+            )
+            ->willReturn(['id' => 'wh-uuid', 'url' => 'https://example.com/hook']);
+
+        $data = (new CreateShippingWebhookData())
+            ->setUrl('https://example.com/hook')
+            ->setEnabledEvents(['shipment.registered']);
+
+        $result = $mock->createWebhook($data);
+
+        $this->assertSame('wh-uuid', $result['id']);
+    }
+
+    public function testListWebhooks(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'GET',
+                $this->stringContains('/webhooks'),
+            )
+            ->willReturn(['data' => []]);
+
+        $result = $mock->listWebhooks();
+
+        $this->assertSame(['data' => []], $result);
+    }
+
+    public function testDeleteWebhook(): void
+    {
+        $mock = $this->createClientMock();
+
+        $mock->expects($this->once())
+            ->method('call')
+            ->with(
+                'DELETE',
+                $this->stringContains('/webhooks/wh-uuid'),
+            )
+            ->willReturn([]);
+
+        $result = $mock->deleteWebhook('wh-uuid');
+
+        $this->assertSame([], $result);
+    }
+}

--- a/tests/Unit/Structs/Shipping/AdditionalServiceTest.php
+++ b/tests/Unit/Structs/Shipping/AdditionalServiceTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs\Shipping;
+
+use Montonio\Structs\Shipping\AdditionalService;
+use Montonio\Structs\Shipping\AdditionalServiceParams;
+use Tests\BaseTestCase;
+
+class AdditionalServiceTest extends BaseTestCase
+{
+    public function testFluentSetters(): void
+    {
+        $service = (new AdditionalService())
+            ->setCode('cod')
+            ->setParams(
+                (new AdditionalServiceParams())->setAmount(25.50)
+            );
+
+        $this->assertSame('cod', $service->getCode());
+        $this->assertSame(25.50, $service->getParams()->getAmount());
+    }
+
+    public function testToArray(): void
+    {
+        $service = (new AdditionalService())
+            ->setCode('cod')
+            ->setParams(
+                (new AdditionalServiceParams())->setAmount(10.00)
+            );
+
+        $array = $service->toArray();
+
+        $this->assertSame('cod', $array['code']);
+        $this->assertSame(10.00, $array['params']['amount']);
+    }
+
+    public function testConstructFromArray(): void
+    {
+        $service = new AdditionalService([
+            'code' => 'ageVerification',
+        ]);
+
+        $this->assertSame('ageVerification', $service->getCode());
+        $this->assertNull($service->getParams());
+    }
+
+    public function testNullableGetters(): void
+    {
+        $service = new AdditionalService();
+
+        $this->assertNull($service->getCode());
+        $this->assertNull($service->getParams());
+    }
+}

--- a/tests/Unit/Structs/Shipping/CreateLabelFileDataTest.php
+++ b/tests/Unit/Structs/Shipping/CreateLabelFileDataTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs\Shipping;
+
+use Montonio\Structs\Shipping\CreateLabelFileData;
+use Tests\BaseTestCase;
+
+class CreateLabelFileDataTest extends BaseTestCase
+{
+    public function testFluentSetters(): void
+    {
+        $data = (new CreateLabelFileData())
+            ->setShipmentIds(['uuid-1', 'uuid-2'])
+            ->setPageSize('A4')
+            ->setLabelsPerPage(4)
+            ->setOrderLabelsBy('carrier')
+            ->setSynchronous(true);
+
+        $this->assertSame(['uuid-1', 'uuid-2'], $data->getShipmentIds());
+        $this->assertSame('A4', $data->getPageSize());
+        $this->assertSame(4, $data->getLabelsPerPage());
+        $this->assertSame('carrier', $data->getOrderLabelsBy());
+        $this->assertTrue($data->getSynchronous());
+    }
+
+    public function testToArray(): void
+    {
+        $data = (new CreateLabelFileData())
+            ->setShipmentIds(['uuid-1'])
+            ->setPageSize('A6');
+
+        $array = $data->toArray();
+
+        $this->assertSame(['uuid-1'], $array['shipmentIds']);
+        $this->assertSame('A6', $array['pageSize']);
+    }
+
+    public function testNullableGetters(): void
+    {
+        $data = new CreateLabelFileData();
+
+        $this->assertNull($data->getPageSize());
+        $this->assertNull($data->getLabelsPerPage());
+        $this->assertNull($data->getOrderLabelsBy());
+        $this->assertNull($data->getSynchronous());
+    }
+}

--- a/tests/Unit/Structs/Shipping/CreateShipmentDataTest.php
+++ b/tests/Unit/Structs/Shipping/CreateShipmentDataTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs\Shipping;
+
+use Montonio\Structs\Shipping\CreateShipmentData;
+use Montonio\Structs\Shipping\ShipmentParcel;
+use Montonio\Structs\Shipping\ShipmentProduct;
+use Montonio\Structs\Shipping\ShipmentShippingMethod;
+use Montonio\Structs\Shipping\ShippingContact;
+use Tests\BaseTestCase;
+
+class CreateShipmentDataTest extends BaseTestCase
+{
+    public function testFluentSetters(): void
+    {
+        $data = (new CreateShipmentData())
+            ->setShippingMethod(
+                (new ShipmentShippingMethod())
+                    ->setType('pickupPoint')
+                    ->setId('abc-123')
+            )
+            ->setReceiver(
+                (new ShippingContact())
+                    ->setName('Receiver X')
+                    ->setPhoneCountryCode('372')
+                    ->setPhoneNumber('53334770')
+            )
+            ->setParcels([
+                (new ShipmentParcel())->setWeight(1.0),
+            ])
+            ->setMerchantReference('order-1')
+            ->setSynchronous(true);
+
+        $this->assertSame('pickupPoint', $data->getShippingMethod()->getType());
+        $this->assertSame('Receiver X', $data->getReceiver()->getName());
+        $this->assertCount(1, $data->getParcels());
+        $this->assertSame('order-1', $data->getMerchantReference());
+        $this->assertTrue($data->getSynchronous());
+    }
+
+    public function testConstructFromArray(): void
+    {
+        $data = new CreateShipmentData([
+            'shippingMethod' => [
+                'type' => 'courier',
+                'id' => 'def-456',
+            ],
+            'receiver' => [
+                'name' => 'Test',
+                'phoneCountryCode' => '372',
+                'phoneNumber' => '555',
+            ],
+            'parcels' => [
+                ['weight' => 2.0],
+            ],
+            'products' => [
+                ['sku' => 'sku-1', 'name' => 'Widget', 'quantity' => 1],
+            ],
+        ]);
+
+        $this->assertInstanceOf(ShipmentShippingMethod::class, $data->getShippingMethod());
+        $this->assertSame('courier', $data->getShippingMethod()->getType());
+        $this->assertInstanceOf(ShippingContact::class, $data->getReceiver());
+        $this->assertInstanceOf(ShipmentParcel::class, $data->getParcels()[0]);
+        $this->assertInstanceOf(ShipmentProduct::class, $data->getProducts()[0]);
+        $this->assertSame('sku-1', $data->getProducts()[0]->getSku());
+    }
+
+    public function testToArray(): void
+    {
+        $data = (new CreateShipmentData())
+            ->setShippingMethod(
+                (new ShipmentShippingMethod())
+                    ->setType('pickupPoint')
+                    ->setId('abc-123')
+            )
+            ->setReceiver(
+                (new ShippingContact())
+                    ->setName('Test')
+                    ->setPhoneCountryCode('372')
+                    ->setPhoneNumber('555')
+            )
+            ->setParcels([
+                (new ShipmentParcel())->setWeight(1.5),
+            ]);
+
+        $array = $data->toArray();
+
+        $this->assertSame('pickupPoint', $array['shippingMethod']['type']);
+        $this->assertSame('Test', $array['receiver']['name']);
+        $this->assertSame(1.5, $array['parcels'][0]['weight']);
+    }
+
+    public function testNullableGetters(): void
+    {
+        $data = new CreateShipmentData();
+
+        $this->assertNull($data->getShippingMethod());
+        $this->assertNull($data->getReceiver());
+        $this->assertNull($data->getSender());
+        $this->assertNull($data->getMerchantReference());
+        $this->assertNull($data->getMontonioOrderUuid());
+        $this->assertNull($data->getOrderComment());
+        $this->assertNull($data->getSynchronous());
+    }
+}

--- a/tests/Unit/Structs/Shipping/CreateShipmentDataTest.php
+++ b/tests/Unit/Structs/Shipping/CreateShipmentDataTest.php
@@ -27,16 +27,32 @@ class CreateShipmentDataTest extends BaseTestCase
                     ->setPhoneCountryCode('372')
                     ->setPhoneNumber('53334770')
             )
+            ->setSender(
+                (new ShippingContact())
+                    ->setName('Sender Y')
+                    ->setPhoneCountryCode('370')
+                    ->setPhoneNumber('12345678')
+            )
             ->setParcels([
                 (new ShipmentParcel())->setWeight(1.0),
             ])
+            ->setProducts([
+                (new ShipmentProduct())->setSku('sku-1')->setName('Widget')->setQuantity(2),
+            ])
             ->setMerchantReference('order-1')
+            ->setMontonioOrderUuid('montonio-uuid-123')
+            ->setOrderComment('Please handle with care')
             ->setSynchronous(true);
 
         $this->assertSame('pickupPoint', $data->getShippingMethod()->getType());
         $this->assertSame('Receiver X', $data->getReceiver()->getName());
+        $this->assertSame('Sender Y', $data->getSender()->getName());
         $this->assertCount(1, $data->getParcels());
+        $this->assertCount(1, $data->getProducts());
+        $this->assertSame('sku-1', $data->getProducts()[0]->getSku());
         $this->assertSame('order-1', $data->getMerchantReference());
+        $this->assertSame('montonio-uuid-123', $data->getMontonioOrderUuid());
+        $this->assertSame('Please handle with care', $data->getOrderComment());
         $this->assertTrue($data->getSynchronous());
     }
 

--- a/tests/Unit/Structs/Shipping/CreateShippingWebhookDataTest.php
+++ b/tests/Unit/Structs/Shipping/CreateShippingWebhookDataTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs\Shipping;
+
+use Montonio\Structs\Shipping\CreateShippingWebhookData;
+use Tests\BaseTestCase;
+
+class CreateShippingWebhookDataTest extends BaseTestCase
+{
+    public function testFluentSetters(): void
+    {
+        $data = (new CreateShippingWebhookData())
+            ->setUrl('https://example.com/webhook')
+            ->setEnabledEvents(['shipment.registered', 'shipment.statusUpdated']);
+
+        $this->assertSame('https://example.com/webhook', $data->getUrl());
+        $this->assertSame(['shipment.registered', 'shipment.statusUpdated'], $data->getEnabledEvents());
+    }
+
+    public function testToArray(): void
+    {
+        $data = (new CreateShippingWebhookData())
+            ->setUrl('https://example.com/webhook')
+            ->setEnabledEvents(['shipment.registered']);
+
+        $array = $data->toArray();
+
+        $this->assertSame('https://example.com/webhook', $array['url']);
+        $this->assertSame(['shipment.registered'], $array['enabledEvents']);
+    }
+
+    public function testNullableGetters(): void
+    {
+        $data = new CreateShippingWebhookData();
+
+        $this->assertNull($data->getUrl());
+    }
+}

--- a/tests/Unit/Structs/Shipping/FilterByParcelsDataTest.php
+++ b/tests/Unit/Structs/Shipping/FilterByParcelsDataTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs\Shipping;
+
+use Montonio\Structs\Shipping\FilterByParcelsData;
+use Montonio\Structs\Shipping\ShipmentParcel;
+use Tests\BaseTestCase;
+
+class FilterByParcelsDataTest extends BaseTestCase
+{
+    public function testFromArray(): void
+    {
+        $data = new FilterByParcelsData([
+            'parcels' => [
+                ['weight' => 1.5],
+            ],
+        ]);
+
+        $this->assertCount(1, $data->getParcels());
+        $this->assertInstanceOf(ShipmentParcel::class, $data->getParcels()[0]);
+        $this->assertSame(1.5, $data->getParcels()[0]->getWeight());
+    }
+
+    public function testToArray(): void
+    {
+        $data = (new FilterByParcelsData())
+            ->setParcels([
+                (new ShipmentParcel())->setWeight(2.0)->setHeight(0.5),
+            ]);
+
+        $array = $data->toArray();
+
+        $this->assertSame(2.0, $array['parcels'][0]['weight']);
+        $this->assertSame(0.5, $array['parcels'][0]['height']);
+    }
+}

--- a/tests/Unit/Structs/Shipping/RatesItemTest.php
+++ b/tests/Unit/Structs/Shipping/RatesItemTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs\Shipping;
+
+use Montonio\Structs\Shipping\RatesItem;
+use Tests\BaseTestCase;
+
+class RatesItemTest extends BaseTestCase
+{
+    public function testFluentSetters(): void
+    {
+        $item = (new RatesItem())
+            ->setLength(20.0)
+            ->setWidth(15.0)
+            ->setHeight(10.0)
+            ->setWeight(0.5)
+            ->setDimensionUnit('cm')
+            ->setWeightUnit('kg')
+            ->setQuantity(2);
+
+        $this->assertSame(20.0, $item->getLength());
+        $this->assertSame(15.0, $item->getWidth());
+        $this->assertSame(10.0, $item->getHeight());
+        $this->assertSame(0.5, $item->getWeight());
+        $this->assertSame('cm', $item->getDimensionUnit());
+        $this->assertSame('kg', $item->getWeightUnit());
+        $this->assertSame(2, $item->getQuantity());
+    }
+
+    public function testToArray(): void
+    {
+        $item = (new RatesItem())
+            ->setLength(20.0)
+            ->setWidth(15.0)
+            ->setHeight(10.0)
+            ->setWeight(0.5);
+
+        $array = $item->toArray();
+
+        $this->assertSame(20.0, $array['length']);
+        $this->assertSame(0.5, $array['weight']);
+    }
+
+    public function testNullableGetters(): void
+    {
+        $item = new RatesItem();
+
+        $this->assertNull($item->getLength());
+        $this->assertNull($item->getDimensionUnit());
+        $this->assertNull($item->getQuantity());
+    }
+}

--- a/tests/Unit/Structs/Shipping/RatesParcelTest.php
+++ b/tests/Unit/Structs/Shipping/RatesParcelTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs\Shipping;
+
+use Montonio\Structs\Shipping\RatesItem;
+use Montonio\Structs\Shipping\RatesParcel;
+use Tests\BaseTestCase;
+
+class RatesParcelTest extends BaseTestCase
+{
+    public function testSetItemsFromArray(): void
+    {
+        $parcel = new RatesParcel([
+            'items' => [
+                ['length' => 20.0, 'width' => 15.0, 'height' => 10.0, 'weight' => 0.5],
+            ],
+        ]);
+
+        $items = $parcel->getItems();
+        $this->assertCount(1, $items);
+        $this->assertInstanceOf(RatesItem::class, $items[0]);
+        $this->assertSame(20.0, $items[0]->getLength());
+    }
+
+    public function testToArray(): void
+    {
+        $parcel = (new RatesParcel())
+            ->setItems([
+                (new RatesItem())->setLength(10.0)->setWidth(5.0)->setHeight(3.0)->setWeight(1.0),
+            ]);
+
+        $array = $parcel->toArray();
+
+        $this->assertSame(10.0, $array['items'][0]['length']);
+        $this->assertSame(1.0, $array['items'][0]['weight']);
+    }
+}

--- a/tests/Unit/Structs/Shipping/ShipmentParcelTest.php
+++ b/tests/Unit/Structs/Shipping/ShipmentParcelTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs\Shipping;
+
+use Montonio\Structs\Shipping\ShipmentParcel;
+use Tests\BaseTestCase;
+
+class ShipmentParcelTest extends BaseTestCase
+{
+    public function testFluentSettersAndGetters(): void
+    {
+        $parcel = (new ShipmentParcel())
+            ->setWeight(2.5)
+            ->setHeight(0.64)
+            ->setWidth(0.38)
+            ->setLength(0.39);
+
+        $this->assertSame(2.5, $parcel->getWeight());
+        $this->assertSame(0.64, $parcel->getHeight());
+        $this->assertSame(0.38, $parcel->getWidth());
+        $this->assertSame(0.39, $parcel->getLength());
+    }
+
+    public function testToArray(): void
+    {
+        $parcel = (new ShipmentParcel())
+            ->setWeight(1.0)
+            ->setLength(0.5);
+
+        $array = $parcel->toArray();
+
+        $this->assertSame(1.0, $array['weight']);
+        $this->assertSame(0.5, $array['length']);
+    }
+
+    public function testConstructFromArray(): void
+    {
+        $parcel = new ShipmentParcel([
+            'weight' => 3.0,
+            'height' => 0.2,
+        ]);
+
+        $this->assertSame(3.0, $parcel->getWeight());
+        $this->assertSame(0.2, $parcel->getHeight());
+    }
+
+    public function testNullableGetters(): void
+    {
+        $parcel = new ShipmentParcel();
+
+        $this->assertNull($parcel->getWeight());
+        $this->assertNull($parcel->getHeight());
+        $this->assertNull($parcel->getWidth());
+        $this->assertNull($parcel->getLength());
+    }
+}

--- a/tests/Unit/Structs/Shipping/ShipmentProductTest.php
+++ b/tests/Unit/Structs/Shipping/ShipmentProductTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs\Shipping;
+
+use Montonio\Structs\Shipping\ShipmentProduct;
+use Tests\BaseTestCase;
+
+class ShipmentProductTest extends BaseTestCase
+{
+    public function testFluentSetters(): void
+    {
+        $product = (new ShipmentProduct())
+            ->setSku('product-123')
+            ->setName('Blue Police Car')
+            ->setQuantity(3)
+            ->setBarcode('0123456789123')
+            ->setPrice(19.99)
+            ->setCurrency('EUR')
+            ->setAttributes(['color' => 'Blue'])
+            ->setImageUrl('https://example.com/image.jpg')
+            ->setStoreProductUrl('https://example.com/product')
+            ->setDescription('A blue toy car');
+
+        $this->assertSame('product-123', $product->getSku());
+        $this->assertSame('Blue Police Car', $product->getName());
+        $this->assertSame(3.0, $product->getQuantity());
+        $this->assertSame('0123456789123', $product->getBarcode());
+        $this->assertSame(19.99, $product->getPrice());
+        $this->assertSame('EUR', $product->getCurrency());
+        $this->assertSame(['color' => 'Blue'], $product->getAttributes());
+        $this->assertSame('https://example.com/image.jpg', $product->getImageUrl());
+    }
+
+    public function testConstructFromArray(): void
+    {
+        $product = new ShipmentProduct([
+            'sku' => 'sku-1',
+            'name' => 'Widget',
+            'quantity' => 5,
+        ]);
+
+        $this->assertSame('sku-1', $product->getSku());
+        $this->assertSame('Widget', $product->getName());
+        $this->assertSame(5.0, $product->getQuantity());
+    }
+
+    public function testToArray(): void
+    {
+        $product = (new ShipmentProduct())
+            ->setSku('sku-1')
+            ->setName('Item')
+            ->setQuantity(1);
+
+        $array = $product->toArray();
+
+        $this->assertSame('sku-1', $array['sku']);
+        $this->assertSame('Item', $array['name']);
+    }
+
+    public function testNullableGetters(): void
+    {
+        $product = new ShipmentProduct();
+
+        $this->assertNull($product->getSku());
+        $this->assertNull($product->getBarcode());
+        $this->assertNull($product->getPrice());
+        $this->assertNull($product->getDescription());
+    }
+}

--- a/tests/Unit/Structs/Shipping/ShipmentProductTest.php
+++ b/tests/Unit/Structs/Shipping/ShipmentProductTest.php
@@ -31,6 +31,8 @@ class ShipmentProductTest extends BaseTestCase
         $this->assertSame('EUR', $product->getCurrency());
         $this->assertSame(['color' => 'Blue'], $product->getAttributes());
         $this->assertSame('https://example.com/image.jpg', $product->getImageUrl());
+        $this->assertSame('https://example.com/product', $product->getStoreProductUrl());
+        $this->assertSame('A blue toy car', $product->getDescription());
     }
 
     public function testConstructFromArray(): void

--- a/tests/Unit/Structs/Shipping/ShipmentShippingMethodTest.php
+++ b/tests/Unit/Structs/Shipping/ShipmentShippingMethodTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs\Shipping;
+
+use Montonio\Structs\Shipping\AdditionalService;
+use Montonio\Structs\Shipping\ShipmentShippingMethod;
+use Tests\BaseTestCase;
+
+class ShipmentShippingMethodTest extends BaseTestCase
+{
+    public function testFluentSetters(): void
+    {
+        $method = (new ShipmentShippingMethod())
+            ->setType('courier')
+            ->setId('aeada198-fab7-4042-a414-82dcf3ea81e8')
+            ->setParcelHandoverMethod('courierPickUp')
+            ->setLockerSize('M');
+
+        $this->assertSame('courier', $method->getType());
+        $this->assertSame('aeada198-fab7-4042-a414-82dcf3ea81e8', $method->getId());
+        $this->assertSame('courierPickUp', $method->getParcelHandoverMethod());
+        $this->assertSame('M', $method->getLockerSize());
+    }
+
+    public function testAdditionalServicesFromArray(): void
+    {
+        $method = new ShipmentShippingMethod([
+            'type' => 'pickupPoint',
+            'id' => 'abc-123',
+            'additionalServices' => [
+                ['code' => 'cod', 'params' => ['amount' => 25.50]],
+                ['code' => 'ageVerification'],
+            ],
+        ]);
+
+        $services = $method->getAdditionalServices();
+        $this->assertCount(2, $services);
+        $this->assertInstanceOf(AdditionalService::class, $services[0]);
+        $this->assertSame('cod', $services[0]->getCode());
+        $this->assertSame(25.50, $services[0]->getParams()->getAmount());
+        $this->assertSame('ageVerification', $services[1]->getCode());
+    }
+
+    public function testToArray(): void
+    {
+        $method = (new ShipmentShippingMethod())
+            ->setType('courier')
+            ->setId('abc-123')
+            ->setAdditionalServices([
+                (new AdditionalService())->setCode('cod'),
+            ]);
+
+        $array = $method->toArray();
+
+        $this->assertSame('courier', $array['type']);
+        $this->assertSame('abc-123', $array['id']);
+        $this->assertSame('cod', $array['additionalServices'][0]['code']);
+    }
+
+    public function testNullableGetters(): void
+    {
+        $method = new ShipmentShippingMethod();
+
+        $this->assertNull($method->getType());
+        $this->assertNull($method->getId());
+        $this->assertNull($method->getParcelHandoverMethod());
+        $this->assertNull($method->getLockerSize());
+    }
+}

--- a/tests/Unit/Structs/Shipping/ShippingContactTest.php
+++ b/tests/Unit/Structs/Shipping/ShippingContactTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs\Shipping;
+
+use Montonio\Structs\Shipping\ShippingContact;
+use Tests\BaseTestCase;
+
+class ShippingContactTest extends BaseTestCase
+{
+    public function testFluentSetters(): void
+    {
+        $contact = (new ShippingContact())
+            ->setName('Receiver X')
+            ->setPhoneCountryCode('372')
+            ->setPhoneNumber('53334770')
+            ->setFirstName('John')
+            ->setLastName('Doe')
+            ->setStreetAddress('Kai 1')
+            ->setLocality('Tallinn')
+            ->setPostalCode('10111')
+            ->setCountry('EE')
+            ->setRegion('Harjumaa')
+            ->setEmail('john@example.com')
+            ->setCompanyName('Acme Corp');
+
+        $this->assertSame('Receiver X', $contact->getName());
+        $this->assertSame('372', $contact->getPhoneCountryCode());
+        $this->assertSame('53334770', $contact->getPhoneNumber());
+        $this->assertSame('John', $contact->getFirstName());
+        $this->assertSame('Doe', $contact->getLastName());
+        $this->assertSame('Kai 1', $contact->getStreetAddress());
+        $this->assertSame('Tallinn', $contact->getLocality());
+        $this->assertSame('10111', $contact->getPostalCode());
+        $this->assertSame('EE', $contact->getCountry());
+        $this->assertSame('Harjumaa', $contact->getRegion());
+        $this->assertSame('john@example.com', $contact->getEmail());
+        $this->assertSame('Acme Corp', $contact->getCompanyName());
+    }
+
+    public function testConstructFromArray(): void
+    {
+        $contact = new ShippingContact([
+            'name' => 'Sender Y',
+            'phoneCountryCode' => '370',
+            'phoneNumber' => '12345678',
+            'streetAddress' => 'Main St 5',
+        ]);
+
+        $this->assertSame('Sender Y', $contact->getName());
+        $this->assertSame('370', $contact->getPhoneCountryCode());
+        $this->assertSame('Main St 5', $contact->getStreetAddress());
+    }
+
+    public function testToArray(): void
+    {
+        $contact = (new ShippingContact())
+            ->setName('Test')
+            ->setPhoneCountryCode('372')
+            ->setPhoneNumber('555');
+
+        $array = $contact->toArray();
+
+        $this->assertSame('Test', $array['name']);
+        $this->assertSame('372', $array['phoneCountryCode']);
+        $this->assertSame('555', $array['phoneNumber']);
+    }
+
+    public function testNullableGetters(): void
+    {
+        $contact = new ShippingContact();
+
+        $this->assertNull($contact->getName());
+        $this->assertNull($contact->getFirstName());
+        $this->assertNull($contact->getEmail());
+    }
+}

--- a/tests/Unit/Structs/Shipping/ShippingRatesDataTest.php
+++ b/tests/Unit/Structs/Shipping/ShippingRatesDataTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs\Shipping;
+
+use Montonio\Structs\Shipping\RatesItem;
+use Montonio\Structs\Shipping\RatesParcel;
+use Montonio\Structs\Shipping\ShippingRatesData;
+use Tests\BaseTestCase;
+
+class ShippingRatesDataTest extends BaseTestCase
+{
+    public function testFluentSetters(): void
+    {
+        $data = (new ShippingRatesData())
+            ->setDestination('EE')
+            ->setParcels([
+                (new RatesParcel())->setItems([
+                    (new RatesItem())
+                        ->setLength(20.0)
+                        ->setWidth(15.0)
+                        ->setHeight(10.0)
+                        ->setWeight(0.5),
+                ]),
+            ]);
+
+        $this->assertSame('EE', $data->getDestination());
+        $this->assertCount(1, $data->getParcels());
+        $this->assertSame(20.0, $data->getParcels()[0]->getItems()[0]->getLength());
+    }
+
+    public function testToArray(): void
+    {
+        $data = (new ShippingRatesData())
+            ->setDestination('LT')
+            ->setParcels([
+                (new RatesParcel())->setItems([
+                    (new RatesItem())
+                        ->setLength(10.0)
+                        ->setWidth(5.0)
+                        ->setHeight(3.0)
+                        ->setWeight(1.0)
+                        ->setDimensionUnit('cm')
+                        ->setWeightUnit('kg'),
+                ]),
+            ]);
+
+        $array = $data->toArray();
+
+        $this->assertSame('LT', $array['destination']);
+        $this->assertSame('cm', $array['parcels'][0]['items'][0]['dimensionUnit']);
+    }
+
+    public function testNullableGetters(): void
+    {
+        $data = new ShippingRatesData();
+
+        $this->assertNull($data->getDestination());
+    }
+}

--- a/tests/Unit/Structs/Shipping/ShippingRatesDataTest.php
+++ b/tests/Unit/Structs/Shipping/ShippingRatesDataTest.php
@@ -52,6 +52,19 @@ class ShippingRatesDataTest extends BaseTestCase
         $this->assertSame('cm', $array['parcels'][0]['items'][0]['dimensionUnit']);
     }
 
+    public function testConstructFromArray(): void
+    {
+        $data = new ShippingRatesData([
+            'destination' => 'FI',
+            'parcels' => [
+                ['items' => [['length' => 5.0, 'width' => 5.0, 'height' => 5.0, 'weight' => 0.3]]],
+            ],
+        ]);
+
+        $this->assertSame('FI', $data->getDestination());
+        $this->assertInstanceOf(RatesParcel::class, $data->getParcels()[0]);
+    }
+
     public function testNullableGetters(): void
     {
         $data = new ShippingRatesData();

--- a/tests/Unit/Structs/Shipping/UpdateShipmentDataTest.php
+++ b/tests/Unit/Structs/Shipping/UpdateShipmentDataTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs\Shipping;
+
+use Montonio\Structs\Shipping\ShipmentParcel;
+use Montonio\Structs\Shipping\ShipmentShippingMethod;
+use Montonio\Structs\Shipping\ShippingContact;
+use Montonio\Structs\Shipping\UpdateShipmentData;
+use Tests\BaseTestCase;
+
+class UpdateShipmentDataTest extends BaseTestCase
+{
+    public function testFluentSetters(): void
+    {
+        $data = (new UpdateShipmentData())
+            ->setShippingMethod(
+                (new ShipmentShippingMethod())->setType('courier')->setId('abc-123')
+            )
+            ->setReceiver(
+                (new ShippingContact())->setName('Receiver')->setPhoneCountryCode('372')->setPhoneNumber('555')
+            )
+            ->setSender(
+                (new ShippingContact())->setName('Sender')->setPhoneCountryCode('370')->setPhoneNumber('666')
+            )
+            ->setParcels([
+                (new ShipmentParcel())->setWeight(2.0),
+            ]);
+
+        $this->assertSame('courier', $data->getShippingMethod()->getType());
+        $this->assertSame('Receiver', $data->getReceiver()->getName());
+        $this->assertSame('Sender', $data->getSender()->getName());
+        $this->assertCount(1, $data->getParcels());
+        $this->assertSame(2.0, $data->getParcels()[0]->getWeight());
+    }
+
+    public function testConstructFromArray(): void
+    {
+        $data = new UpdateShipmentData([
+            'shippingMethod' => [
+                'type' => 'pickupPoint',
+                'id' => 'pp-456',
+            ],
+            'receiver' => [
+                'name' => 'Test',
+                'phoneCountryCode' => '372',
+                'phoneNumber' => '555',
+            ],
+            'parcels' => [
+                ['weight' => 1.5],
+            ],
+        ]);
+
+        $this->assertInstanceOf(ShipmentShippingMethod::class, $data->getShippingMethod());
+        $this->assertSame('pickupPoint', $data->getShippingMethod()->getType());
+        $this->assertInstanceOf(ShippingContact::class, $data->getReceiver());
+        $this->assertInstanceOf(ShipmentParcel::class, $data->getParcels()[0]);
+    }
+
+    public function testToArray(): void
+    {
+        $data = (new UpdateShipmentData())
+            ->setReceiver(
+                (new ShippingContact())->setName('Updated')->setPhoneCountryCode('372')->setPhoneNumber('555')
+            )
+            ->setParcels([
+                (new ShipmentParcel())->setWeight(3.0),
+            ]);
+
+        $array = $data->toArray();
+
+        $this->assertSame('Updated', $array['receiver']['name']);
+        $this->assertSame(3.0, $array['parcels'][0]['weight']);
+    }
+
+    public function testNullableGetters(): void
+    {
+        $data = new UpdateShipmentData();
+
+        $this->assertNull($data->getShippingMethod());
+        $this->assertNull($data->getReceiver());
+        $this->assertNull($data->getSender());
+    }
+}


### PR DESCRIPTION
## Summary
- Split AbstractClient into shared base + PaymentsAbstractClient + ShippingAbstractClient
- Added 14 shipping structs under `Montonio\Structs\Shipping` namespace
- Added 5 shipping sub-clients: Carriers, ShippingMethods, Shipments, LabelFiles, ShippingWebhooks
- Entry point: `$client->shipping()->shipments()->createShipment($data)`
- Covers all 14 [Shipping V2 API](https://docs.montonio.com/api/shipping-v2/reference) endpoints
- Removed `@codeCoverageIgnore` from `PayoutsClient::exportPayout()` by adding mocked unit test