### PR TITLE
chore: support 1.x branch in CI and release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,6 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
+filter-by-commitish: true
 categories:
   - title: 'Features'
     labels:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '1.x'
 
 permissions:
   contents: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '1.x'
     paths:
       - '**.php'
       - '.github/workflows/tests.yml'


### PR DESCRIPTION
## Summary
- Added `1.x` branch to test suite and release-drafter workflow triggers
- Added `filter-by-commitish` to release-drafter so each branch gets its own release draft