### PR TITLE
feat!: v2 modernization

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "composer"
+    directory: "/"
+    target-branch: "1.x"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "1.x"
     schedule:
       interval: "weekly"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,11 +23,10 @@ jobs:
     strategy:
       matrix:
         php:
-          - 8.0
-          - 8.1
           - 8.2
           - 8.3
           - 8.4
+          - 8.5
     name: PHP ${{matrix.php }} Unit Test
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ PHP SDK for the [Montonio Stargate API](https://docs.montonio.com/api/stargate/)
 
 ## Features
 
+- **Full API coverage** — Payments (Stargate) and Shipping V2 APIs
+- **PSR-18 support** — bring your own HTTP client (Guzzle, Symfony, etc.) or use the built-in cURL transport
+- **Fluent struct builders** — build request payloads with chained setters, array hydration, or `static create()` with named parameters
+- **Typed enums** — `Environment`, `PaymentMethod`, `PaymentStatus` backed enums with full IDE support
+- **Granular exceptions** — `AuthenticationException`, `ValidationException`, `NotFoundException`, `RateLimitException`, `ServerException`
+- **JWT authentication** — token generation, webhook signature verification
+
+### API Coverage
+
 | Client | Methods | API Docs |
 |--------|---------|----------|
 | **Orders** | `createOrder`, `getOrder` | [Orders guide](https://docs.montonio.com/api/stargate/guides/orders) |
@@ -27,8 +36,8 @@ Supported payment methods: bank payments, card payments (Apple Pay, Google Pay),
 
 ## Requirements
 
-- PHP 8.0 or later
-- cURL extension
+- PHP 8.2 or later
+- cURL extension (or a PSR-18 HTTP client)
 
 ## Installation
 
@@ -51,6 +60,27 @@ $client = new MontonioClient(
 ```
 
 All sub-clients are accessed via factory methods on the main client (e.g. `$client->orders()`, `$client->refunds()`).
+
+## Custom HTTP Client (PSR-18)
+
+By default, the SDK uses cURL for HTTP requests. You can optionally provide your own PSR-18 HTTP client:
+
+```php
+use Montonio\MontonioClient;
+
+$httpFactory = new \Nyholm\Psr7\Factory\Psr17Factory();
+
+$client = new MontonioClient(
+    $accessKey,
+    $secretKey,
+    MontonioClient::ENVIRONMENT_SANDBOX,
+    httpClient: new \GuzzleHttp\Client(),
+    requestFactory: $httpFactory,
+    streamFactory: $httpFactory,
+);
+```
+
+This is useful for testing (inject a mock client) or when your framework already provides an HTTP client.
 
 ## Orders
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Supported payment methods: bank payments, card payments (Apple Pay, Google Pay),
 - PHP 8.2 or later
 - cURL extension (or a PSR-18 HTTP client)
 
+> **Using PHP 8.0 or 8.1?** [v1 (1.x branch)](https://github.com/makstech/montonio-php-sdk/tree/1.x) is actively maintained with full API coverage (Payments + Shipping):
+> ```shell
+> composer require makstech/montonio-php-sdk:^1.0
+> ```
+
 ## Installation
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Supported payment methods: bank payments, card payments (Apple Pay, Google Pay),
 > composer require makstech/montonio-php-sdk:^1.0
 > ```
 
+> **Upgrading from v1?** See the [upgrade guide](UPGRADE.md) — most users need no code changes.
+
 ## Installation
 
 ```shell

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,117 @@
+# Upgrading from v1 to v2
+
+For most users, **upgrading is seamless** — your existing code will work without changes. The public API (structs, factory methods, array responses, webhook decoding) is unchanged. v2 focuses on modernization: PSR-18 support, enums, and a richer exception hierarchy.
+
+The only hard requirement is **PHP 8.2+**. Beyond that, v2 introduces several deprecations (old exception classes, string constants) that still work but should be migrated before v3.
+
+## Requirements
+
+- **PHP 8.2+** is now required (was 8.0+).
+
+## Installation
+
+```shell
+composer require makstech/montonio-php-sdk:^2.0
+```
+
+## Breaking Changes
+
+### Exception classes
+
+`CurlErrorException` has been renamed to `TransportException`. The old class still exists as a deprecated alias — existing `catch` blocks will continue to work.
+
+`RequestException` is now a deprecated alias for `ApiException`. Existing `catch (RequestException $e)` blocks still work.
+
+New specific exception types are available for more precise error handling:
+
+```php
+use Montonio\Exception\AuthenticationException; // 401, 403
+use Montonio\Exception\ValidationException;     // 400, 422
+use Montonio\Exception\NotFoundException;       // 404
+use Montonio\Exception\RateLimitException;      // 429
+use Montonio\Exception\ServerException;         // 500+
+use Montonio\Exception\ApiException;            // base for all API errors
+use Montonio\Exception\TransportException;      // network/transport failures
+```
+
+### CurlHandle nullable
+
+`ApiException::getCurlHandle()` returns `?CurlHandle` instead of `CurlHandle`. It is `null` when using a PSR-18 HTTP client.
+
+## Deprecations
+
+The following are deprecated in v2 and will be removed in v3:
+
+### Constants replaced by Enums
+
+| Deprecated Constant | Use Instead |
+|---|---|
+| `MontonioClient::ENVIRONMENT_SANDBOX` | `Environment::Sandbox` |
+| `MontonioClient::ENVIRONMENT_LIVE` | `Environment::Live` |
+| `Payment::METHOD_PAYMENT_INITIATION` | `PaymentMethod::PaymentInitiation` |
+| `Payment::METHOD_CARD` | `PaymentMethod::CardPayments` |
+| `Payment::METHOD_BLIK` | `PaymentMethod::Blik` |
+| `Payment::METHOD_HIRE_PURCHASE` | `PaymentMethod::HirePurchase` |
+| `Payment::METHOD_BUY_NOW_PAY_LATER` | `PaymentMethod::BuyNowPayLater` |
+| `OrderData::STATUS_PENDING` | `PaymentStatus::Pending` |
+| `OrderData::STATUS_PAID` | `PaymentStatus::Paid` |
+| `OrderData::STATUS_VOIDED` | `PaymentStatus::Voided` |
+| `OrderData::STATUS_PARTIALLY_REFUNDED` | `PaymentStatus::PartiallyRefunded` |
+| `OrderData::STATUS_REFUNDED` | `PaymentStatus::Refunded` |
+| `OrderData::STATUS_ABANDONED` | `PaymentStatus::Abandoned` |
+| `OrderData::STATUS_AUTHORIZED` | `PaymentStatus::Authorized` |
+
+### Exception classes
+
+| Deprecated Class | Use Instead |
+|---|---|
+| `RequestException` | `ApiException` |
+| `CurlErrorException` | `TransportException` |
+
+### Exception methods
+
+| Deprecated Method | Use Instead |
+|---|---|
+| `$e->getResponse()` | `$e->getResponseBody()` |
+| `$e->curlHandle()` | `$e->getCurlHandle()` |
+
+## New Features
+
+### PSR-18 HTTP Client Support
+
+You can now inject a custom PSR-18 HTTP client instead of using the built-in cURL transport:
+
+```php
+$client = new MontonioClient(
+    $accessKey,
+    $secretKey,
+    'live',
+    httpClient: $yourPsr18Client,
+    requestFactory: $yourPsr17RequestFactory,
+    streamFactory: $yourPsr17StreamFactory,
+);
+```
+
+### Static `create()` Factory
+
+All structs now support a `create()` static factory with named parameters:
+
+```php
+$refund = CreateRefundData::create(
+    orderUuid: $uuid,
+    amount: 10.00,
+);
+```
+
+### Enums
+
+Native PHP 8.1 backed enums are available for environments, payment methods, and payment statuses. Setters accept both enums and strings.
+
+## No Changes Needed
+
+The following work exactly as before:
+- Fluent struct builders (`new OrderData()` + setters)
+- Array hydration (`new OrderData([...])`)
+- Array responses from all client methods
+- Factory methods (`$client->orders()`, `$client->shipping()`, etc.)
+- Webhook token decoding (`$client->decodeToken()`)

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,20 @@
   "license": "MIT",
   "homepage": "https://github.com/makstech/montonio-php-sdk",
   "require": {
-    "php": "^8.0",
+    "php": "^8.2",
     "ext-curl": "*",
-    "firebase/php-jwt": "^6.0 || ^7.0"
+    "firebase/php-jwt": "^6.0 || ^7.0",
+    "psr/http-client": "^1.0",
+    "psr/http-factory": "^1.0",
+    "psr/http-message": "^1.1 || ^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.6",
+    "phpunit/phpunit": "^11.0",
     "vlucas/phpdotenv": "^5.6"
+  },
+  "suggest": {
+    "guzzlehttp/guzzle": "PSR-18 HTTP client implementation",
+    "nyholm/psr7": "Lightweight PSR-7/PSR-17 implementation"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,7 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          colors="true"
+         failOnDeprecation="false"
 >
     <testsuites>
         <testsuite name="Integration">
@@ -13,9 +14,9 @@
         </testsuite>
     </testsuites>
 
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/src/Clients/AbstractClient.php
+++ b/src/Clients/AbstractClient.php
@@ -5,23 +5,46 @@ declare(strict_types=1);
 namespace Montonio\Clients;
 
 use CurlHandle;
-use Exception;
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
 use JsonException;
+use Montonio\Enums\Environment;
+use Montonio\Exception\ApiException;
+use Montonio\Exception\AuthenticationException;
 use Montonio\Exception\CurlErrorException;
-use Montonio\Exception\RequestException;
+use Montonio\Exception\NotFoundException;
+use Montonio\Exception\RateLimitException;
+use Montonio\Exception\ServerException;
+use Montonio\Exception\TransportException;
+use Montonio\Exception\ValidationException;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use stdClass;
 
 abstract class AbstractClient
 {
     protected const ENCODING_ALGORITHM = 'HS256';
 
+    private readonly string $environment;
+
     public function __construct(
-        private string $accessKey,
-        private string $secretKey,
-        private string $environment,
-    ) {}
+        private readonly string $accessKey,
+        private readonly string $secretKey,
+        Environment|string $environment,
+        private readonly ?ClientInterface $httpClient = null,
+        private readonly ?RequestFactoryInterface $requestFactory = null,
+        private readonly ?StreamFactoryInterface $streamFactory = null,
+    ) {
+        $this->environment = $environment instanceof Environment ? $environment->value : $environment;
+
+        if ($this->httpClient !== null && ($this->requestFactory === null || $this->streamFactory === null)) {
+            throw new \InvalidArgumentException(
+                'When providing a PSR-18 ClientInterface, you must also provide RequestFactoryInterface and StreamFactoryInterface.'
+            );
+        }
+    }
 
     public function generateToken(array $payload = []): string
     {
@@ -47,6 +70,96 @@ abstract class AbstractClient
         return JWT::decode($token, new Key($this->getSecretKey(), static::ENCODING_ALGORITHM));
     }
 
+    protected function call(string $method, string $url, ?string $payload = null, array $headers = []): array
+    {
+        if ($this->httpClient !== null) {
+            return $this->callPsr18($method, $url, $payload, $headers);
+        }
+
+        return $this->callCurl($method, $url, $payload, $headers);
+    }
+
+    private function callPsr18(string $method, string $url, ?string $payload, array $headers): array
+    {
+        $request = $this->requestFactory->createRequest($method, $url);
+
+        foreach ($headers as $header) {
+            [$name, $value] = explode(':', $header, 2);
+            $request = $request->withHeader(trim($name), trim($value));
+        }
+
+        if ($payload !== null && $method !== 'GET') {
+            $request = $request->withBody($this->streamFactory->createStream($payload));
+        }
+
+        try {
+            $response = $this->httpClient->sendRequest($request);
+        } catch (ClientExceptionInterface $e) {
+            throw new TransportException($e->getMessage(), (int) $e->getCode(), null, $e);
+        }
+
+        return $this->handleResponse(
+            $response->getStatusCode(),
+            (string) $response->getBody(),
+        );
+    }
+
+    private function callCurl(string $method, string $url, ?string $payload, array $headers): array
+    {
+        $ch = $this->prepareCurl($url);
+
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+
+        if ($payload !== null && $method !== 'GET') {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+        }
+
+        $response = curl_exec($ch);
+
+        // @codeCoverageIgnoreStart
+        if ($response === false) {
+            throw new TransportException(curl_error($ch), curl_errno($ch), $ch);
+            // @codeCoverageIgnoreEnd
+        }
+
+        return $this->handleResponse(
+            (int) curl_getinfo($ch, CURLINFO_HTTP_CODE),
+            $response,
+            $ch,
+        );
+    }
+
+    private function handleResponse(int $httpStatus, string $response, ?CurlHandle $ch = null): array
+    {
+        if ($httpStatus >= 200 && $httpStatus <= 299) {
+            if ($ch !== null) {
+                curl_close($ch);
+            }
+            return json_decode($response, true) ?? [];
+        }
+
+        $message = '';
+        if ($httpStatus >= 400) {
+            try {
+                $body = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+                $message = $body['error'] ?? '';
+                // @codeCoverageIgnoreStart
+            } catch (JsonException) {
+                // @codeCoverageIgnoreEnd
+            }
+        }
+
+        match (true) {
+            $httpStatus === 401, $httpStatus === 403 => throw new AuthenticationException($message, $httpStatus, $response, $ch),
+            $httpStatus === 404 => throw new NotFoundException($message, $httpStatus, $response, $ch),
+            $httpStatus === 429 => throw new RateLimitException($message, $httpStatus, $response, $ch),
+            $httpStatus === 400, $httpStatus === 422 => throw new ValidationException($message, $httpStatus, $response, $ch),
+            $httpStatus >= 500 => throw new ServerException($message, $httpStatus, $response, $ch),
+            default => throw new ApiException($message, $httpStatus, $response, $ch),
+        };
+    }
+
     private function prepareCurl(string $url): CurlHandle
     {
         $ch = curl_init();
@@ -58,57 +171,6 @@ abstract class AbstractClient
         curl_setopt($ch, CURLOPT_HEADER, false);
 
         return $ch;
-    }
-
-    /**
-     * @throws Exception
-     */
-    protected function call(string $method, string $url, ?string $payload = null, array $headers = []): array
-    {
-        $ch = $this->prepareCurl($url);
-
-        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-
-        if ($payload && $method !== 'GET') {
-            curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
-        }
-
-        return $this->execute($ch);
-    }
-
-    /**
-     * @throws Exception
-     */
-    private function execute(CurlHandle $ch): array
-    {
-        $response = curl_exec($ch);
-
-        // @codeCoverageIgnoreStart
-        if ($response === false) {
-            throw new CurlErrorException(curl_error($ch), curl_errno($ch), $ch);
-            // @codeCoverageIgnoreEnd
-        }
-
-        $httpStatus = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        if (200 <= $httpStatus && $httpStatus <= 299) {
-            curl_close($ch);
-            return json_decode($response, true) ?? [];
-        }
-
-        $message = '';
-
-        if (400 <= $httpStatus && $httpStatus <= 499) {
-            try {
-                $body = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
-                $message = $body['error'] ?? '';
-                // @codeCoverageIgnoreStart
-            } catch (JsonException $e) {
-                // @codeCoverageIgnoreEnd
-            }
-        }
-
-        throw new RequestException($message, $httpStatus, $response, $ch);
     }
 
     protected function getAccessKey(): string
@@ -124,5 +186,20 @@ abstract class AbstractClient
     protected function getEnvironment(): string
     {
         return $this->environment;
+    }
+
+    protected function getHttpClient(): ?ClientInterface
+    {
+        return $this->httpClient;
+    }
+
+    protected function getRequestFactory(): ?RequestFactoryInterface
+    {
+        return $this->requestFactory;
+    }
+
+    protected function getStreamFactory(): ?StreamFactoryInterface
+    {
+        return $this->streamFactory;
     }
 }

--- a/src/Clients/AbstractClient.php
+++ b/src/Clients/AbstractClient.php
@@ -11,7 +11,6 @@ use JsonException;
 use Montonio\Enums\Environment;
 use Montonio\Exception\ApiException;
 use Montonio\Exception\AuthenticationException;
-use Montonio\Exception\CurlErrorException;
 use Montonio\Exception\NotFoundException;
 use Montonio\Exception\RateLimitException;
 use Montonio\Exception\ServerException;

--- a/src/Clients/Shipping/ShippingClient.php
+++ b/src/Clients/Shipping/ShippingClient.php
@@ -21,6 +21,9 @@ class ShippingClient extends ShippingAbstractClient
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),
+            $this->getHttpClient(),
+            $this->getRequestFactory(),
+            $this->getStreamFactory(),
         );
     }
 
@@ -30,6 +33,9 @@ class ShippingClient extends ShippingAbstractClient
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),
+            $this->getHttpClient(),
+            $this->getRequestFactory(),
+            $this->getStreamFactory(),
         );
     }
 
@@ -39,6 +45,9 @@ class ShippingClient extends ShippingAbstractClient
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),
+            $this->getHttpClient(),
+            $this->getRequestFactory(),
+            $this->getStreamFactory(),
         );
     }
 
@@ -48,6 +57,9 @@ class ShippingClient extends ShippingAbstractClient
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),
+            $this->getHttpClient(),
+            $this->getRequestFactory(),
+            $this->getStreamFactory(),
         );
     }
 
@@ -57,6 +69,9 @@ class ShippingClient extends ShippingAbstractClient
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),
+            $this->getHttpClient(),
+            $this->getRequestFactory(),
+            $this->getStreamFactory(),
         );
     }
 }

--- a/src/Enums/Environment.php
+++ b/src/Enums/Environment.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Enums;
+
+enum Environment: string
+{
+    case Sandbox = 'sandbox';
+    case Live = 'live';
+}

--- a/src/Enums/PaymentMethod.php
+++ b/src/Enums/PaymentMethod.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Enums;
+
+enum PaymentMethod: string
+{
+    case PaymentInitiation = 'paymentInitiation';
+    case CardPayments = 'cardPayments';
+    case Blik = 'blik';
+    case HirePurchase = 'hirePurchase';
+    case BuyNowPayLater = 'bnpl';
+}

--- a/src/Enums/PaymentStatus.php
+++ b/src/Enums/PaymentStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Enums;
+
+enum PaymentStatus: string
+{
+    case Pending = 'PENDING';
+    case Paid = 'PAID';
+    case Voided = 'VOIDED';
+    case PartiallyRefunded = 'PARTIALLY_REFUNDED';
+    case Refunded = 'REFUNDED';
+    case Abandoned = 'ABANDONED';
+    case Authorized = 'AUTHORIZED';
+}

--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Exception;
+
+/**
+ * Base exception for all Montonio API HTTP errors.
+ *
+ * Prefer catching this class (or its subclasses) over the deprecated RequestException.
+ */
+class ApiException extends RequestException {}

--- a/src/Exception/AuthenticationException.php
+++ b/src/Exception/AuthenticationException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Exception;
+
+class AuthenticationException extends ApiException {}

--- a/src/Exception/CurlErrorException.php
+++ b/src/Exception/CurlErrorException.php
@@ -7,19 +7,18 @@ namespace Montonio\Exception;
 use CurlHandle;
 use Throwable;
 
+/**
+ * @deprecated Use TransportException instead. Will be removed in v3.
+ */
 class CurlErrorException extends MontonioException
 {
-    private ?CurlHandle $curlHandle;
-
     public function __construct(
         string $message = '',
         int $code = 0,
-        CurlHandle $ch = null,
-        ?Throwable $previous = null
+        private readonly ?CurlHandle $curlHandle = null,
+        ?Throwable $previous = null,
     ) {
         parent::__construct($message, $code, $previous);
-
-        $this->curlHandle = $ch;
     }
 
     public function getCurlHandle(): ?CurlHandle

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Exception;
+
+class NotFoundException extends ApiException {}

--- a/src/Exception/RateLimitException.php
+++ b/src/Exception/RateLimitException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Exception;
+
+class RateLimitException extends ApiException {}

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -7,30 +7,48 @@ namespace Montonio\Exception;
 use CurlHandle;
 use Throwable;
 
+/**
+ * @deprecated Use ApiException or its subclasses instead. Will be removed in v3.
+ */
 class RequestException extends MontonioException
 {
-    private string $response;
-    private ?CurlHandle $curlHandle;
-
     public function __construct(
         string $message = '',
         int $code = 0,
-        string $response = '',
-        ?CurlHandle $curlHandle = null,
-        ?Throwable $previous = null
+        private readonly string $responseBody = '',
+        private readonly ?CurlHandle $curlHandle = null,
+        ?Throwable $previous = null,
     ) {
         parent::__construct($message, $code, $previous);
-
-        $this->response = $response;
-        $this->curlHandle = $curlHandle;
     }
 
+    public function getStatusCode(): int
+    {
+        return $this->getCode();
+    }
+
+    public function getResponseBody(): string
+    {
+        return $this->responseBody;
+    }
+
+    public function getCurlHandle(): ?CurlHandle
+    {
+        return $this->curlHandle;
+    }
+
+    /**
+     * @deprecated Use getResponseBody() instead. Will be removed in v3.
+     */
     public function getResponse(): string
     {
-        return $this->response;
+        return $this->responseBody;
     }
 
-    public function curlHandle(): CurlHandle
+    /**
+     * @deprecated Use getCurlHandle() instead. Will be removed in v3.
+     */
+    public function curlHandle(): ?CurlHandle
     {
         return $this->curlHandle;
     }

--- a/src/Exception/ServerException.php
+++ b/src/Exception/ServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Exception;
+
+class ServerException extends ApiException {}

--- a/src/Exception/TransportException.php
+++ b/src/Exception/TransportException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Exception;
+
+/**
+ * Exception for network/transport failures.
+ *
+ * Prefer catching this class over the deprecated CurlErrorException.
+ */
+class TransportException extends CurlErrorException {}

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Montonio\Exception;
+
+class ValidationException extends ApiException {}

--- a/src/MontonioClient.php
+++ b/src/MontonioClient.php
@@ -16,7 +16,9 @@ use Montonio\Clients\StoresClient;
 
 class MontonioClient extends PaymentsAbstractClient
 {
+    /** @deprecated Use Environment::Sandbox instead. Will be removed in v3. */
     public const ENVIRONMENT_SANDBOX = 'sandbox';
+    /** @deprecated Use Environment::Live instead. Will be removed in v3. */
     public const ENVIRONMENT_LIVE = 'live';
 
     public function orders(): OrdersClient
@@ -25,6 +27,9 @@ class MontonioClient extends PaymentsAbstractClient
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),
+            $this->getHttpClient(),
+            $this->getRequestFactory(),
+            $this->getStreamFactory(),
         );
     }
 
@@ -34,6 +39,9 @@ class MontonioClient extends PaymentsAbstractClient
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),
+            $this->getHttpClient(),
+            $this->getRequestFactory(),
+            $this->getStreamFactory(),
         );
     }
 
@@ -43,6 +51,9 @@ class MontonioClient extends PaymentsAbstractClient
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),
+            $this->getHttpClient(),
+            $this->getRequestFactory(),
+            $this->getStreamFactory(),
         );
     }
 
@@ -52,6 +63,9 @@ class MontonioClient extends PaymentsAbstractClient
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),
+            $this->getHttpClient(),
+            $this->getRequestFactory(),
+            $this->getStreamFactory(),
         );
     }
 
@@ -61,6 +75,9 @@ class MontonioClient extends PaymentsAbstractClient
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),
+            $this->getHttpClient(),
+            $this->getRequestFactory(),
+            $this->getStreamFactory(),
         );
     }
 
@@ -70,6 +87,9 @@ class MontonioClient extends PaymentsAbstractClient
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),
+            $this->getHttpClient(),
+            $this->getRequestFactory(),
+            $this->getStreamFactory(),
         );
     }
 
@@ -79,6 +99,9 @@ class MontonioClient extends PaymentsAbstractClient
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),
+            $this->getHttpClient(),
+            $this->getRequestFactory(),
+            $this->getStreamFactory(),
         );
     }
 
@@ -88,6 +111,9 @@ class MontonioClient extends PaymentsAbstractClient
             $this->getAccessKey(),
             $this->getSecretKey(),
             $this->getEnvironment(),
+            $this->getHttpClient(),
+            $this->getRequestFactory(),
+            $this->getStreamFactory(),
         );
     }
 }

--- a/src/Structs/AbstractStruct.php
+++ b/src/Structs/AbstractStruct.php
@@ -52,6 +52,20 @@ abstract class AbstractStruct
         return $this;
     }
 
+    public static function create(mixed ...$args): static
+    {
+        $instance = new static();
+
+        foreach ($args as $field => $value) {
+            $setter = 'set' . ucfirst($field);
+            if (method_exists($instance, $setter)) {
+                $instance->$setter($value);
+            }
+        }
+
+        return $instance;
+    }
+
     public function toArray(): array
     {
         $return = [];

--- a/src/Structs/OrderData.php
+++ b/src/Structs/OrderData.php
@@ -12,12 +12,19 @@ class OrderData extends AbstractStruct
 {
     use Currency, Locale, NotificationUrl;
 
+    /** @deprecated Use PaymentStatus::Pending instead. Will be removed in v3. */
     public const STATUS_PENDING = 'PENDING';
+    /** @deprecated Use PaymentStatus::Paid instead. Will be removed in v3. */
     public const STATUS_PAID = 'PAID';
+    /** @deprecated Use PaymentStatus::Voided instead. Will be removed in v3. */
     public const STATUS_VOIDED = 'VOIDED';
+    /** @deprecated Use PaymentStatus::PartiallyRefunded instead. Will be removed in v3. */
     public const STATUS_PARTIALLY_REFUNDED = 'PARTIALLY_REFUNDED';
+    /** @deprecated Use PaymentStatus::Refunded instead. Will be removed in v3. */
     public const STATUS_REFUNDED = 'REFUNDED';
+    /** @deprecated Use PaymentStatus::Abandoned instead. Will be removed in v3. */
     public const STATUS_ABANDONED = 'ABANDONED';
+    /** @deprecated Use PaymentStatus::Authorized instead. Will be removed in v3. */
     public const STATUS_AUTHORIZED = 'AUTHORIZED';
 
     protected string $merchantReference;

--- a/src/Structs/Payment.php
+++ b/src/Structs/Payment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Montonio\Structs;
 
+use Montonio\Enums\PaymentMethod;
 use Montonio\Structs\Fields\Amount;
 use Montonio\Structs\Fields\Currency;
 
@@ -11,11 +12,17 @@ class Payment extends AbstractStruct
 {
     use Amount, Currency;
 
+    /** @deprecated Use PaymentMethod::PaymentInitiation instead. Will be removed in v3. */
     public const METHOD_PAYMENT_INITIATION = 'paymentInitiation';
+    /** @deprecated Use PaymentMethod::CardPayments instead. Will be removed in v3. */
     public const METHOD_CARD = 'cardPayments';
+    /** @deprecated Use PaymentMethod::Blik instead. Will be removed in v3. */
     public const METHOD_BLIK = 'blik';
+    /** @deprecated Use PaymentMethod::HirePurchase instead. Will be removed in v3. */
     public const METHOD_HIRE_PURCHASE = 'hirePurchase';
+    /** @deprecated Use PaymentMethod::BuyNowPayLater instead. Will be removed in v3. */
     public const METHOD_BUY_NOW_PAY_LATER = 'bnpl';
+
     protected string $method;
     protected string $methodDisplay;
     protected PaymentMethodOptions $methodOptions;
@@ -27,11 +34,10 @@ class Payment extends AbstractStruct
 
     /**
      * The Identifier of the Montonio Payment Method.
-     * Use one of predefined const's defined in this class.
      */
-    public function setMethod(string $method): self
+    public function setMethod(PaymentMethod|string $method): self
     {
-        $this->method = $method;
+        $this->method = $method instanceof PaymentMethod ? $method->value : $method;
 
         return $this;
     }

--- a/tests/Integration/Clients/PaymentIntentsClientTest.php
+++ b/tests/Integration/Clients/PaymentIntentsClientTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Clients;
 
 use CurlHandle;
-use Montonio\Exception\RequestException;
+use Montonio\Exception\ApiException;
 use Montonio\Structs\CreatePaymentIntentDraftData;
 use Montonio\Structs\Payment;
 use Tests\Integration\IntegrationTestCase;
@@ -28,12 +28,12 @@ class PaymentIntentsClientTest extends IntegrationTestCase
     public function testCreateDraft_fails_missingRequiredData(): void
     {
         try {
-            $response = $this->getMontonioClient()->paymentIntents()->createDraft(new CreatePaymentIntentDraftData());
-        } catch (RequestException $e) {
+            $this->getMontonioClient()->paymentIntents()->createDraft(new CreatePaymentIntentDraftData());
+        } catch (ApiException $e) {
         } finally {
-            $this->assertInstanceOf(RequestException::class, $e);
-            $this->assertJson($e->getResponse());
-            $this->assertInstanceOf(CurlHandle::class, $e->curlHandle());
+            $this->assertInstanceOf(ApiException::class, $e);
+            $this->assertJson($e->getResponseBody());
+            $this->assertInstanceOf(CurlHandle::class, $e->getCurlHandle());
         }
     }
 }

--- a/tests/Integration/Clients/RefundsClientTest.php
+++ b/tests/Integration/Clients/RefundsClientTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Clients;
 
-use Montonio\Exception\RequestException;
+use Montonio\Exception\ApiException;
 use Montonio\Structs\CreateRefundData;
 use Tests\BaseTestCase;
 
@@ -17,7 +17,7 @@ class RefundsClientTest extends BaseTestCase
             ->setAmount(1.00)
             ->setIdempotencyKey(uniqid('test-', true));
 
-        $this->expectException(RequestException::class);
+        $this->expectException(ApiException::class);
 
         $this->getMontonioClient()->refunds()->createRefund($data);
     }

--- a/tests/Integration/Clients/Shipping/LabelFilesClientTest.php
+++ b/tests/Integration/Clients/Shipping/LabelFilesClientTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Clients\Shipping;
 
-use Montonio\Exception\RequestException;
+use Montonio\Exception\ApiException;
 use Montonio\Structs\Shipping\CreateLabelFileData;
 use Montonio\Structs\Shipping\CreateShipmentData;
 use Montonio\Structs\Shipping\ShipmentParcel;
@@ -21,7 +21,7 @@ class LabelFilesClientTest extends IntegrationTestCase
         // Get a pickup point ID
         try {
             $methods = $client->shippingMethods()->getShippingMethods();
-        } catch (RequestException $e) {
+        } catch (ApiException $e) {
             $this->markTestSkipped('Shipping methods not available in sandbox: ' . $e->getMessage());
         }
 

--- a/tests/Integration/Clients/Shipping/ShipmentsClientTest.php
+++ b/tests/Integration/Clients/Shipping/ShipmentsClientTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Clients\Shipping;
 
-use Montonio\Exception\RequestException;
+use Montonio\Exception\ApiException;
 use Montonio\Structs\Shipping\CreateShipmentData;
 use Montonio\Structs\Shipping\ShipmentParcel;
 use Montonio\Structs\Shipping\ShipmentShippingMethod;
@@ -20,7 +20,7 @@ class ShipmentsClientTest extends IntegrationTestCase
 
         try {
             $methods = $client->shippingMethods()->getShippingMethods();
-        } catch (RequestException $e) {
+        } catch (ApiException $e) {
             $this->markTestSkipped('Shipping methods not available in sandbox: ' . $e->getMessage());
         }
 

--- a/tests/Integration/Clients/Shipping/ShippingMethodsClientTest.php
+++ b/tests/Integration/Clients/Shipping/ShippingMethodsClientTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Clients\Shipping;
 
-use Montonio\Exception\RequestException;
+use Montonio\Exception\ApiException;
 use Montonio\Structs\Shipping\FilterByParcelsData;
 use Montonio\Structs\Shipping\RatesItem;
 use Montonio\Structs\Shipping\RatesParcel;
@@ -18,7 +18,7 @@ class ShippingMethodsClientTest extends IntegrationTestCase
     {
         try {
             return $this->getMontonioClient()->shipping()->shippingMethods()->getShippingMethods();
-        } catch (RequestException $e) {
+        } catch (ApiException $e) {
             $this->markTestSkipped('Shipping methods not available in sandbox: ' . $e->getMessage());
         }
     }

--- a/tests/Unit/Clients/PsrClientTest.php
+++ b/tests/Unit/Clients/PsrClientTest.php
@@ -88,7 +88,7 @@ class PsrClientTest extends BaseTestCase
         );
     }
 
-    public function testPsr18SuccessfulResponse(): void
+    public function testPsr18SuccessfulGetResponse(): void
     {
         $client = $this->createPsrClient(200, '{"paymentMethods":[]}');
 
@@ -96,6 +96,16 @@ class PsrClientTest extends BaseTestCase
 
         $this->assertIsArray($result);
         $this->assertArrayHasKey('paymentMethods', $result);
+    }
+
+    public function testPsr18SuccessfulPostResponse(): void
+    {
+        $client = $this->createPsrClient(200, '{"uuid":"test-uuid"}');
+
+        $result = $client->sessions()->createSession();
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('uuid', $result);
     }
 
     public function testPsr18TransportException(): void

--- a/tests/Unit/Clients/PsrClientTest.php
+++ b/tests/Unit/Clients/PsrClientTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Clients;
+
+use Montonio\Exception\ApiException;
+use Montonio\Exception\AuthenticationException;
+use Montonio\Exception\NotFoundException;
+use Montonio\Exception\RateLimitException;
+use Montonio\Exception\ServerException;
+use Montonio\Exception\TransportException;
+use Montonio\Exception\ValidationException;
+use Montonio\MontonioClient;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Tests\BaseTestCase;
+
+class PsrClientTest extends BaseTestCase
+{
+    public function testConstructorRequiresFactoriesWithHttpClient(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new MontonioClient(
+            ACCESS_KEY,
+            SECRET_KEY,
+            'sandbox',
+            $this->createStub(ClientInterface::class),
+        );
+    }
+
+    public function testConstructorAcceptsFullPsrTrio(): void
+    {
+        $client = new MontonioClient(
+            ACCESS_KEY,
+            SECRET_KEY,
+            'sandbox',
+            $this->createStub(ClientInterface::class),
+            $this->createStub(RequestFactoryInterface::class),
+            $this->createStub(StreamFactoryInterface::class),
+        );
+
+        $this->assertInstanceOf(MontonioClient::class, $client);
+    }
+
+    public function testConstructorWorksWithoutPsr(): void
+    {
+        $client = new MontonioClient(ACCESS_KEY, SECRET_KEY, 'sandbox');
+
+        $this->assertInstanceOf(MontonioClient::class, $client);
+    }
+
+    private function createPsrClient(int $statusCode, string $body): MontonioClient
+    {
+        $stream = $this->createStub(StreamInterface::class);
+        $stream->method('__toString')->willReturn($body);
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn($statusCode);
+        $response->method('getBody')->willReturn($stream);
+
+        $httpClient = $this->createStub(ClientInterface::class);
+        $httpClient->method('sendRequest')->willReturn($response);
+
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('withHeader')->willReturn($request);
+        $request->method('withBody')->willReturn($request);
+
+        $requestFactory = $this->createStub(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturn($request);
+
+        $streamFactory = $this->createStub(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')->willReturn($stream);
+
+        return new MontonioClient(
+            ACCESS_KEY,
+            SECRET_KEY,
+            'sandbox',
+            $httpClient,
+            $requestFactory,
+            $streamFactory,
+        );
+    }
+
+    public function testPsr18SuccessfulResponse(): void
+    {
+        $client = $this->createPsrClient(200, '{"paymentMethods":[]}');
+
+        $result = $client->stores()->getPaymentMethods();
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('paymentMethods', $result);
+    }
+
+    public function testPsr18TransportException(): void
+    {
+        $exception = new class ('connection failed') extends \RuntimeException implements ClientExceptionInterface {};
+
+        $httpClient = $this->createStub(ClientInterface::class);
+        $httpClient->method('sendRequest')->willThrowException($exception);
+
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('withHeader')->willReturn($request);
+        $request->method('withBody')->willReturn($request);
+
+        $requestFactory = $this->createStub(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturn($request);
+
+        $streamFactory = $this->createStub(StreamFactoryInterface::class);
+
+        $client = new MontonioClient(
+            ACCESS_KEY,
+            SECRET_KEY,
+            'sandbox',
+            $httpClient,
+            $requestFactory,
+            $streamFactory,
+        );
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('connection failed');
+        $client->stores()->getPaymentMethods();
+    }
+
+    public function testPsr18AuthenticationException(): void
+    {
+        $client = $this->createPsrClient(401, '{"error":"unauthorized"}');
+
+        $this->expectException(AuthenticationException::class);
+        $client->stores()->getPaymentMethods();
+    }
+
+    public function testPsr18ValidationException(): void
+    {
+        $client = $this->createPsrClient(400, '{"error":"bad request"}');
+
+        $this->expectException(ValidationException::class);
+        $client->stores()->getPaymentMethods();
+    }
+
+    public function testPsr18NotFoundException(): void
+    {
+        $client = $this->createPsrClient(404, '{"error":"not found"}');
+
+        $this->expectException(NotFoundException::class);
+        $client->stores()->getPaymentMethods();
+    }
+
+    public function testPsr18ServerException(): void
+    {
+        $client = $this->createPsrClient(500, '{"error":"internal"}');
+
+        $this->expectException(ServerException::class);
+        $client->stores()->getPaymentMethods();
+    }
+
+    public function testPsr18RateLimitException(): void
+    {
+        $client = $this->createPsrClient(429, '{"error":"too many requests"}');
+
+        $this->expectException(RateLimitException::class);
+        $client->stores()->getPaymentMethods();
+    }
+
+    public function testPsr18ForbiddenThrowsAuthenticationException(): void
+    {
+        $client = $this->createPsrClient(403, '{"error":"forbidden"}');
+
+        $this->expectException(AuthenticationException::class);
+        $client->stores()->getPaymentMethods();
+    }
+
+    public function testPsr18UnprocessableEntityThrowsValidationException(): void
+    {
+        $client = $this->createPsrClient(422, '{"error":"unprocessable"}');
+
+        $this->expectException(ValidationException::class);
+        $client->stores()->getPaymentMethods();
+    }
+
+    public function testPsr18UnmappedStatusThrowsApiException(): void
+    {
+        $client = $this->createPsrClient(409, '{"error":"conflict"}');
+
+        $this->expectException(ApiException::class);
+        $client->stores()->getPaymentMethods();
+    }
+
+    public function testPsr18EmptyResponseReturnsEmptyArray(): void
+    {
+        $client = $this->createPsrClient(204, '');
+
+        $result = $client->stores()->getPaymentMethods();
+
+        $this->assertSame([], $result);
+    }
+}

--- a/tests/Unit/Enums/EnvironmentTest.php
+++ b/tests/Unit/Enums/EnvironmentTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Enums;
+
+use Montonio\Enums\Environment;
+use Montonio\MontonioClient;
+use Tests\BaseTestCase;
+
+class EnvironmentTest extends BaseTestCase
+{
+    public function testValues(): void
+    {
+        $this->assertSame('sandbox', Environment::Sandbox->value);
+        $this->assertSame('live', Environment::Live->value);
+    }
+
+    public function testMatchesDeprecatedConstants(): void
+    {
+        $this->assertSame(MontonioClient::ENVIRONMENT_SANDBOX, Environment::Sandbox->value);
+        $this->assertSame(MontonioClient::ENVIRONMENT_LIVE, Environment::Live->value);
+    }
+}

--- a/tests/Unit/Enums/PaymentMethodTest.php
+++ b/tests/Unit/Enums/PaymentMethodTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Enums;
+
+use Montonio\Enums\PaymentMethod;
+use Montonio\Structs\Payment;
+use Tests\BaseTestCase;
+
+class PaymentMethodTest extends BaseTestCase
+{
+    public function testValues(): void
+    {
+        $this->assertSame('paymentInitiation', PaymentMethod::PaymentInitiation->value);
+        $this->assertSame('cardPayments', PaymentMethod::CardPayments->value);
+        $this->assertSame('blik', PaymentMethod::Blik->value);
+        $this->assertSame('hirePurchase', PaymentMethod::HirePurchase->value);
+        $this->assertSame('bnpl', PaymentMethod::BuyNowPayLater->value);
+    }
+
+    public function testSetMethodAcceptsEnum(): void
+    {
+        $payment = (new Payment())->setMethod(PaymentMethod::Blik);
+
+        $this->assertSame('blik', $payment->getMethod());
+    }
+
+    public function testSetMethodAcceptsString(): void
+    {
+        $payment = (new Payment())->setMethod('paymentInitiation');
+
+        $this->assertSame('paymentInitiation', $payment->getMethod());
+    }
+
+    public function testMatchesDeprecatedConstants(): void
+    {
+        $this->assertSame(Payment::METHOD_PAYMENT_INITIATION, PaymentMethod::PaymentInitiation->value);
+        $this->assertSame(Payment::METHOD_CARD, PaymentMethod::CardPayments->value);
+        $this->assertSame(Payment::METHOD_BLIK, PaymentMethod::Blik->value);
+    }
+}

--- a/tests/Unit/Enums/PaymentStatusTest.php
+++ b/tests/Unit/Enums/PaymentStatusTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Enums;
+
+use Montonio\Enums\PaymentStatus;
+use Montonio\Structs\OrderData;
+use Tests\BaseTestCase;
+
+class PaymentStatusTest extends BaseTestCase
+{
+    public function testValues(): void
+    {
+        $this->assertSame('PENDING', PaymentStatus::Pending->value);
+        $this->assertSame('PAID', PaymentStatus::Paid->value);
+        $this->assertSame('VOIDED', PaymentStatus::Voided->value);
+        $this->assertSame('PARTIALLY_REFUNDED', PaymentStatus::PartiallyRefunded->value);
+        $this->assertSame('REFUNDED', PaymentStatus::Refunded->value);
+        $this->assertSame('ABANDONED', PaymentStatus::Abandoned->value);
+        $this->assertSame('AUTHORIZED', PaymentStatus::Authorized->value);
+    }
+
+    public function testMatchesDeprecatedConstants(): void
+    {
+        $this->assertSame(OrderData::STATUS_PENDING, PaymentStatus::Pending->value);
+        $this->assertSame(OrderData::STATUS_PAID, PaymentStatus::Paid->value);
+        $this->assertSame(OrderData::STATUS_ABANDONED, PaymentStatus::Abandoned->value);
+    }
+}

--- a/tests/Unit/Exception/ExceptionHierarchyTest.php
+++ b/tests/Unit/Exception/ExceptionHierarchyTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Exception;
+
+use Montonio\Exception\ApiException;
+use Montonio\Exception\AuthenticationException;
+use Montonio\Exception\CurlErrorException;
+use Montonio\Exception\MontonioException;
+use Montonio\Exception\NotFoundException;
+use Montonio\Exception\RateLimitException;
+use Montonio\Exception\RequestException;
+use Montonio\Exception\ServerException;
+use Montonio\Exception\TransportException;
+use Montonio\Exception\ValidationException;
+use Tests\BaseTestCase;
+
+class ExceptionHierarchyTest extends BaseTestCase
+{
+    public function testApiExceptionExtensionChain(): void
+    {
+        $e = new ApiException('test', 400, '{"error":"bad"}');
+
+        $this->assertInstanceOf(RequestException::class, $e);
+        $this->assertInstanceOf(MontonioException::class, $e);
+        $this->assertSame(400, $e->getStatusCode());
+        $this->assertSame('{"error":"bad"}', $e->getResponseBody());
+        $this->assertNull($e->getCurlHandle());
+    }
+
+    public function testSpecificExceptionsExtendApiAndRequest(): void
+    {
+        $exceptions = [
+            new AuthenticationException('', 401),
+            new ValidationException('', 400),
+            new NotFoundException('', 404),
+            new RateLimitException('', 429),
+            new ServerException('', 500),
+        ];
+
+        foreach ($exceptions as $e) {
+            $this->assertInstanceOf(ApiException::class, $e);
+            $this->assertInstanceOf(RequestException::class, $e, get_class($e) . ' must extend RequestException for BC');
+            $this->assertInstanceOf(MontonioException::class, $e);
+        }
+    }
+
+    public function testTransportExceptionExtensionChain(): void
+    {
+        $e = new TransportException('connection failed', 7);
+
+        $this->assertInstanceOf(CurlErrorException::class, $e);
+        $this->assertInstanceOf(MontonioException::class, $e);
+        $this->assertSame('connection failed', $e->getMessage());
+        $this->assertNull($e->getCurlHandle());
+    }
+
+    public function testRequestExceptionBcMethods(): void
+    {
+        $e = new RequestException('not found', 404, '{"error":"not found"}');
+
+        $this->assertInstanceOf(MontonioException::class, $e);
+        $this->assertSame(404, $e->getStatusCode());
+        $this->assertSame('{"error":"not found"}', $e->getResponseBody());
+        $this->assertSame('{"error":"not found"}', $e->getResponse());
+        $this->assertNull($e->curlHandle());
+    }
+
+    public function testCurlErrorExceptionBcMethods(): void
+    {
+        $e = new CurlErrorException('timeout', 28);
+
+        $this->assertInstanceOf(MontonioException::class, $e);
+        $this->assertNull($e->getCurlHandle());
+    }
+
+    public function testCatchRequestExceptionCatchesApiExceptions(): void
+    {
+        $caught = false;
+
+        try {
+            throw new ValidationException('bad', 400, '{}');
+        } catch (RequestException $e) {
+            $caught = true;
+        }
+
+        $this->assertTrue($caught, 'catch (RequestException) must catch ValidationException for BC');
+    }
+
+    public function testCatchCurlErrorExceptionCatchesTransportException(): void
+    {
+        $caught = false;
+
+        try {
+            throw new TransportException('fail', 7);
+        } catch (CurlErrorException $e) {
+            $caught = true;
+        }
+
+        $this->assertTrue($caught, 'catch (CurlErrorException) must catch TransportException for BC');
+    }
+}

--- a/tests/Unit/Structs/AbstractStructCreateTest.php
+++ b/tests/Unit/Structs/AbstractStructCreateTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Structs;
+
+use Montonio\Enums\PaymentMethod;
+use Montonio\Structs\CreateRefundData;
+use Montonio\Structs\Payment;
+use Montonio\Structs\Shipping\CreateShipmentData;
+use Montonio\Structs\Shipping\ShipmentParcel;
+use Montonio\Structs\Shipping\ShipmentShippingMethod;
+use Montonio\Structs\Shipping\ShippingContact;
+use Tests\BaseTestCase;
+
+class AbstractStructCreateTest extends BaseTestCase
+{
+    public function testCreateWithNamedArgs(): void
+    {
+        $refund = CreateRefundData::create(
+            orderUuid: '12228dce-2f7c-4db5-8d28-5d82a19aa3b6',
+            amount: 25.00,
+            idempotencyKey: 'key-123',
+        );
+
+        $this->assertInstanceOf(CreateRefundData::class, $refund);
+        $this->assertSame('12228dce-2f7c-4db5-8d28-5d82a19aa3b6', $refund->getOrderUuid());
+        $this->assertSame(25.00, $refund->getAmount());
+        $this->assertSame('key-123', $refund->getIdempotencyKey());
+    }
+
+    public function testCreateProducesCorrectToArray(): void
+    {
+        $refund = CreateRefundData::create(
+            orderUuid: 'uuid-1',
+            amount: 10.00,
+        );
+
+        $array = $refund->toArray();
+
+        $this->assertSame('uuid-1', $array['orderUuid']);
+        $this->assertSame(10.00, $array['amount']);
+    }
+
+    public function testCreateWithNestedStructs(): void
+    {
+        $data = CreateShipmentData::create(
+            shippingMethod: ShipmentShippingMethod::create(
+                type: 'pickupPoint',
+                id: 'pp-123',
+            ),
+            receiver: ShippingContact::create(
+                name: 'John',
+                phoneCountryCode: '372',
+                phoneNumber: '555',
+            ),
+            parcels: [ShipmentParcel::create(weight: 1.0)],
+        );
+
+        $this->assertSame('pickupPoint', $data->getShippingMethod()->getType());
+        $this->assertSame('John', $data->getReceiver()->getName());
+    }
+
+    public function testCreateWithEnum(): void
+    {
+        $payment = Payment::create(
+            method: PaymentMethod::Blik,
+            amount: 100.00,
+            currency: 'PLN',
+        );
+
+        $this->assertSame('blik', $payment->getMethod());
+        $this->assertSame(100.00, $payment->getAmount());
+    }
+
+    public function testCreateIgnoresUnknownFields(): void
+    {
+        $refund = CreateRefundData::create(
+            orderUuid: 'uuid-1',
+            nonExistentField: 'ignored',
+        );
+
+        $this->assertSame('uuid-1', $refund->getOrderUuid());
+    }
+}


### PR DESCRIPTION
## Summary
- PHP ^8.2, PHPUnit 11, CI matrix 8.2-8.5
- PSR-18 HTTP client support (cURL default, optional injection)
- Backed enums: `Environment`, `PaymentMethod`, `PaymentStatus` (constants deprecated)
- Expanded exception hierarchy with status-code mapping
- Static `create()` factory on all structs
- BC aliases for `RequestException` and `CurlErrorException`
- UPGRADE.md migration guide

See [UPGRADE.md](UPGRADE.md) for the full migration guide.